### PR TITLE
[Feat] Add support for gathering full model state from all ranks

### DIFF
--- a/nnscaler/cli/trainer.py
+++ b/nnscaler/cli/trainer.py
@@ -308,6 +308,7 @@ class Trainer:
         We can't broadcast the whole state_dict at once, because it may be too large, and leads to OOM.
         Here we will break the model and optimizer state_dict into smaller pieces and broadcast them one by one.
         Please note we use `torch.distributed.broadcast_object_list` to broadcast the state_dict (including tensors inside).
+        TODO: optimize the broadcast by sending tensors separately.
         """
         dst_ranks = dst_ranks or list(range(torch.distributed.get_world_size()))
         if src_rank not in dst_ranks or self.rank not in dst_ranks:

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -58,7 +58,6 @@ from nnscaler.utils import (
     OptStateDict,
     copy_dynamic,
     broadcast_files,
-    transform_recursively,
     broadcast_mixed_data,
     gather_mixed_data,
 )

--- a/nnscaler/utils.py
+++ b/nnscaler/utils.py
@@ -792,26 +792,6 @@ def broadcast_files(
         _send_file_group(local_rank, file_groups[i], file_group_sizes[i])
 
 
-def broadcast_tensor_list(
-    tensors: List[torch.Tensor],
-    *,
-    src_rank: int = 0,
-    max_batch_size: Optional[int] = None,
-    group: Optional[torch.distributed.ProcessGroup] = None,
-):
-    """
-    Broadcast a list of tensors from src_rank to all other ranks.
-    Small tensors are broadcasted in batches with upper size `max_batch_size` to improve performance.
-
-    Args:
-        tensors (List[torch.Tensor]): The list of tensors to be broadcasted.
-        src_rank (int): The source rank to broadcast from. Default: 0.
-        max_batch_size (int, optional): The maximum batch size for broadcasting.
-        group (torch.distributed.ProcessGroup, optional): The process group to use for broadcasting.
-            If None, the default process group will be used. Default: None.
-    """
-
-
 class _TensorIndex:
     def __init__(self, index: int):
         self.index = index

--- a/nnscaler/utils.py
+++ b/nnscaler/utils.py
@@ -956,9 +956,9 @@ def gather_mixed_data(
 
         for i in range(len(tensors)):
             if rank == src_rank:
-                torch.distributed.recv(cuda_tensors[i], src=sender)
+                torch.distributed.recv(cuda_tensors[i], group_src=sender, group=group)
             else:
-                torch.distributed.send(cuda_tensors[i], dst=src_rank)
+                torch.distributed.send(cuda_tensors[i], group_dst=src_rank, group=group)
 
         if rank == src_rank:
             tensors = [tensor.to(device, non_blocking=True) for tensor in cuda_tensors]

--- a/nnscaler/utils.py
+++ b/nnscaler/utils.py
@@ -808,7 +808,6 @@ def extract_tensors(data: Dict[str, Any]) -> Tuple[Dict[str, Any], List[torch.Te
     Returns:
         Tuple[Dict[str, Any], List[torch.Tensor]]: The skeleton and the list of tensors.
     """
-    skeleton = {}
     tensors = []
 
     # used to deduplicate tensors


### PR DESCRIPTION
Add support for gathering full model state from all ranks. 
A potential usage is when we use nnscaler in RL, and need to sync weights to rollout engine(like vllm)