### PR TITLE
[Feat] Add Muon Support Phase 2(dp with zero1)

### DIFF
--- a/nnscaler/codegen/module/module.py
+++ b/nnscaler/codegen/module/module.py
@@ -533,6 +533,7 @@ class ModuleCodeGen(FuncEmission):
                         f'async_op={CompileFlag.async_reducer}',
                         f'max_bucket_size_bytes={CompileFlag.max_reducer_bucket}',
                         f'zero_use_reduce_scatter={CompileFlag.zero_use_reduce_scatter}',
+                        f'zero_param_level_sharding={CompileFlag.zero_param_level_sharding}',
                         f'**kwargs',
                     ]
                 ) as ib:
@@ -793,6 +794,7 @@ class ModuleCodeGen(FuncEmission):
         max_nbytes = CompileFlag.max_reducer_bucket if not as_parallel_module else 'max_bucket_size_bytes'
         async_op = CompileFlag.async_reducer if not as_parallel_module else 'async_op'
         zero_use_reduce_scatter = CompileFlag.zero_use_reduce_scatter if not as_parallel_module else 'zero_use_reduce_scatter'
+        zero_param_level_sharding = CompileFlag.zero_param_level_sharding if not as_parallel_module else 'zero_param_level_sharding'
 
         zero = CompileFlag.use_zero
         zero_ngroups = CompileFlag.zero_ngroups
@@ -803,6 +805,7 @@ class ModuleCodeGen(FuncEmission):
             "ranks={ranks}, reduce_op={reduce_op}, "
             "async_op={async_op}, zero={zero}, max_bucket_size_bytes={max_nbytes}, "
             "zero_use_reduce_scatter={zero_use_reduce_scatter}, "
+            "zero_param_level_sharding={zero_param_level_sharding},"
             "zero_ngroups={zero_ngroups})"
         )
         reducer_add = 'self.add_reducer({reducer})'
@@ -815,7 +818,8 @@ class ModuleCodeGen(FuncEmission):
         init_code = reducer_init.format(
             reducer=reducer_name, ranks=ranks, reduce_op=reduce_op,
             async_op=async_op, zero=zero, max_nbytes=max_nbytes,
-            zero_ngroups=zero_ngroups, zero_use_reduce_scatter=zero_use_reduce_scatter
+            zero_ngroups=zero_ngroups, zero_use_reduce_scatter=zero_use_reduce_scatter,
+            zero_param_level_sharding=zero_param_level_sharding
         )
         self.model_init_statements.append(init_code)
         # sort weights by first used time (which is gradient all-reduce time in reverse order)

--- a/nnscaler/flags.py
+++ b/nnscaler/flags.py
@@ -66,6 +66,15 @@ class CompileFlag:
     #    hence break the consistency of `.data` and `.grad` of parameters. Need to be careful when using optimizer.
     # 2) `reduce_scatter`` doesn't significantly improve performance comparing with `allreduce`.
     zero_use_reduce_scatter = _to_bool('ZERO_USE_REDUCE_SCATTER')
+    # whether to use parameter level sharding in zero (default False).
+    # This option controls the granularity of sharding parameters in ZeRO.
+    # If set to True, gradients/parameters/optimizer states will be sharded at parameter level.
+    # If set to False, they will be sharded at element level.
+    # NOTE: parameter level sharding may introduce paddings
+    # to make sure all devices have the same size of tensor, which may waste some memory.
+
+    # You must set it to True when Muon optimizer is used.
+    zero_param_level_sharding = _to_bool('ZERO_PARAM_LEVEL_SHARDING')
 
     # use automate mixture precision training, where weights, gradients
     # and optimizer status are kept in its original data type (can be float32),

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -1306,6 +1306,7 @@ HybridOptimizerT = TypeVar('HybridOptimizer', bound=torch.optim.Optimizer)
 PARAM_CLASS_TYPE = Union[
     Tuple[int, int],  # (optimizer_index, param_group_index)
     Tuple[int, int, ParamZeroConfig],  # (optimizer_index, param_group_index, extra_info)
+    Tuple[int, int, dict[str, Any]],  # (optimizer_index, param_group_index, extra_info as dict)
 ]
 
 

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -1304,9 +1304,18 @@ class ParallelOptimizer(torch.optim.Optimizer):
 OptimizerT = TypeVar('OptimizerT', bound=torch.optim.Optimizer)
 HybridOptimizerT = TypeVar('HybridOptimizer', bound=torch.optim.Optimizer)
 PARAM_CLASS_TYPE = Union[
+    # for hybrid optimizer, param_clss can be:
     Tuple[int, int],  # (optimizer_index, param_group_index)
     Tuple[int, int, ParamZeroConfig],  # (optimizer_index, param_group_index, extra_info)
     Tuple[int, int, dict[str, Any]],  # (optimizer_index, param_group_index, extra_info as dict)
+    # for non-hybrid optimizer with param zero, param_clss can be:
+    Tuple[int, ParamZeroConfig],      # (reducer_bucket_sort, extra_info)
+    Tuple[int, dict[str, Any]],       # (reducer_bucket_sort, extra_info as dict)
+    Tuple[ParamZeroConfig],           # (extra_info)
+    Tuple[dict[str, Any]],            # (extra_info as dict)
+    int,                              # reducer_bucket_sort
+    ParamZeroConfig,                  # extra_info
+    dict[str, Any],                   # extra_info as dict
 ]
 
 

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -41,7 +41,7 @@ from nnscaler.ir.operator import IRBpOperation, IRDataOperation
 from nnscaler.ir.tensor import IRFullTensor
 from nnscaler.ir.unique import IDGenerator
 
-from nnscaler.runtime.adapter.reducer import Bucket, Reducer
+from nnscaler.runtime.adapter.reducer import Bucket, Reducer, ParamZeroConfig
 from nnscaler.runtime.device import DeviceGroup
 from nnscaler.runtime.gnorm import calcuate_gnorm, clip_grads
 from nnscaler.runtime.module import AttrMeta, Zero3AttrMeta, CubeModule, ParallelModule, OriginModuleMetadata, ExtraState, dedup_attrs
@@ -1303,11 +1303,15 @@ class ParallelOptimizer(torch.optim.Optimizer):
 
 OptimizerT = TypeVar('OptimizerT', bound=torch.optim.Optimizer)
 HybridOptimizerT = TypeVar('HybridOptimizer', bound=torch.optim.Optimizer)
+PARAM_CLASS_TYPE = Union[
+    Tuple[int, int],  # (optimizer_index, param_group_index)
+    Tuple[int, int, ParamZeroConfig],  # (optimizer_index, param_group_index, extra_info)
+]
 
 
 def hybrid(
     params: list[torch.nn.Parameter],
-    param_clss: dict[torch.nn.Parameter, tuple[int, int]],
+    param_clss: dict[torch.nn.Parameter, PARAM_CLASS_TYPE],
     **kwargs,
 ) -> HybridOptimizerT:
     """

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -104,6 +104,7 @@ class ComputeConfig:
     # 2. In some cases, it can introduce parity issue. So use it with caution.
     zero_use_reduce_scatter: bool = False
     # whether to use parameter level sharding in zero (default False).
+    # This option only works when `use_zero` is not 0.
     # This option controls the granularity of sharding parameters in ZeRO.
     # If set to True, gradients/parameters/optimizer states will be sharded at parameter level.
     # If set to False, they will be sharded at element level.

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -3348,7 +3348,7 @@ def gather_full_model_state_dict(
         state_dicts = gather_mixed_data(local_state_dict, src_rank=0, group=involved_group, device='cpu')
         if rank == 0:
             logger.info(f'Rank {rank}: merging gathered state dicts')
-            merge_state_dict = merge_state_dicts(state_dicts)
+            merge_state_dict = merge_state_dicts(state_dicts)[0]
         else:
             merge_state_dict = None
     else:

--- a/nnscaler/runtime/adapter/reducer.py
+++ b/nnscaler/runtime/adapter/reducer.py
@@ -210,10 +210,12 @@ class FlattenParamInfo:
 class ParamZeroConfig:
     zero_param_level_sharding: Optional[bool] = None
 
-    def resolve(self, zero_param_level_sharding: bool):
+    def resolve(self, zero: int, zero_param_level_sharding: bool):
         return ParamZeroConfig(
-            zero_param_level_sharding=zero_param_level_sharding
-                if self.zero_param_level_sharding is None else self.zero_param_level_sharding
+            zero_param_level_sharding=zero > 0 and (zero_param_level_sharding
+                if self.zero_param_level_sharding is None
+                else self.zero_param_level_sharding
+            )
         )
 
 
@@ -909,7 +911,7 @@ class Reducer:
                         pzc = x[2]
 
                     return tuple(x[:2]) + (
-                        pzc.resolve(self._zero_param_level_sharding),
+                        pzc.resolve(self._zero, self._zero_param_level_sharding),
                     )
                 if len(x) == 2:
                     return tuple(x) + (ParamZeroConfig(zero_param_level_sharding=self._zero_param_level_sharding),)

--- a/nnscaler/runtime/adapter/reducer.py
+++ b/nnscaler/runtime/adapter/reducer.py
@@ -1009,7 +1009,10 @@ class Reducer:
             zero_param_level_sharding = param_cls[-1].zero_param_level_sharding if param_cls else self._zero_param_level_sharding
             param_sizes = [_aligned_nelement(p.nelement(), p.element_size(), self._align_size) for p in params]
             if zero_param_level_sharding and len(params) >= self._zero_size:
-                groups, group_idx = split_array_min_max(param_sizes, self._zero_size, keep_order=False)
+                # TODO: set keep_order=False for less padding
+                # 1. async doesn't work well with keep_order=False
+                # 2. hard to write test cases.
+                groups, group_idx = split_array_min_max(param_sizes, self._zero_size, keep_order=True)
                 max_group_size = max(sum(sizes) for sizes in groups)
                 new_param_order = []
                 for i in range(len(group_idx)):

--- a/nnscaler/runtime/hybrid_optimizer.py
+++ b/nnscaler/runtime/hybrid_optimizer.py
@@ -17,6 +17,7 @@ from nnscaler.utils import fn_field, OptStateDict
 
 if TYPE_CHECKING:
     from nnscaler.cli.trainer import Trainer
+    from nnscaler.parallel import PARAM_CLASS_TYPE
 
 
 @dataclass
@@ -144,7 +145,7 @@ class HybridOptimizer(torch.optim.Optimizer, TrainHookHost, TrainHook):
     def __init__(
             self,
             params: Iterable[torch.nn.Parameter],
-            param_clss: dict[torch.nn.Parameter, tuple[int, int]],
+            param_clss: dict[torch.nn.Parameter, 'PARAM_CLASS_TYPE'],
             config: Union[HybridOptConfig, dict[str, Any]]
     ):
         """
@@ -152,7 +153,7 @@ class HybridOptimizer(torch.optim.Optimizer, TrainHookHost, TrainHook):
 
         Args:
             params (Iterable[torch.nn.Parameter]): The parameters to optimize.
-            param_clss (dict[torch.nn.Parameter, tuple[int, int]]): The parameter classes for each parameter.
+            param_clss (dict[torch.nn.Parameter, PARAM_CLASS_TYPE]): The parameter classes for each parameter.
             config (Union[HybridOptConfig, dict[str, Any]]): The configuration for the hybrid optimizer.
         """
         params = list(params)
@@ -166,7 +167,7 @@ class HybridOptimizer(torch.optim.Optimizer, TrainHookHost, TrainHook):
         param_loc = {}
 
         for idx, param in enumerate(params):
-            param_cls = param_clss[param]
+            param_cls = param_clss[param][:2]
             assert param_cls[0] < len(self.config.optimizers)
             classified_params[param_cls].append(param)
 

--- a/nnscaler/runtime/module.py
+++ b/nnscaler/runtime/module.py
@@ -652,9 +652,6 @@ class CubeModule(torch.nn.Module):
             if 'step' in bucket_states[0]:
                 opt_state_keys.remove('step')
             assert _check_state_size(opt_state_keys, bucket_states[0]), f'the keys {opt_state_keys} have different shape'
-            # NOTE: only support adam for now
-            # assert 'exp_avg' in opt_state_keys
-            # assert 'exp_avg_sq' in opt_state_keys
 
             opt_states, opt_states_1d = {}, {}
             for key in opt_state_keys:

--- a/nnscaler/runtime/muon_optimizer.py
+++ b/nnscaler/runtime/muon_optimizer.py
@@ -1,0 +1,112 @@
+from typing import TYPE_CHECKING
+
+import torch
+
+from nnscaler.runtime.utils import get_fparam_meta, get_dparam_meta
+from nnscaler.utils import OptStateDict
+
+if TYPE_CHECKING:
+    from nnscaler.runtime.adapter.reducer import FlattenParamInfo
+
+
+class MuonMixin:
+    def __init__(self, params, **kwargs):
+        params = list(params)
+        if not params:
+            raise ValueError("optimizer got an empty parameter list")
+
+        self._flat_map: dict[int, tuple[FlattenParamInfo, list[int]]] = {}
+        if isinstance(params[0], dict):
+            if len(params) > 1:
+                raise ValueError("MuonMixin only supports one param group")
+            params[0]['params'] = self._unflatten_params(params[0]['params'])
+        else:
+            params = self._unflatten_params(params)
+
+        super().__init__(params, **kwargs)
+
+    def _unflatten_params(self, params):
+        unflattened_params = []
+        for idx, p in enumerate(params):
+            if fpi := get_fparam_meta(p):
+                if fpi.zero > 1:
+                    raise ValueError("Muon does not support ZeRO3.")
+                p_start = len(unflattened_params)
+                unflattened_params.extend(fpi.get_embeded_params())
+                self._flat_map[idx] = (fpi, list(range(p_start, len(unflattened_params))))
+            else:
+                unflattened_params.append(p)
+                self._flat_map[idx] = (None, [len(unflattened_params) - 1])
+
+        for p in unflattened_params:
+            if dmeta := get_dparam_meta(p):
+                if dmeta.sub_shape != dmeta.shape:
+                    raise ValueError("Muon does not support TP.")
+                if dmeta.sub_shape != p.shape:
+                    raise ValueError("Muon does not support ZeRO3.")
+            else:
+                pass  # normal param from non-parallel module
+
+        return unflattened_params
+
+    def state_dict(self):
+        """
+        Override state_dict to get the flattened states
+        This is necessary to be compatible with other state dict related functions
+        such as merge_state_dict
+        """
+        state: OptStateDict = super().state_dict()
+
+        # called from hybrid optimizer before call `.step` (to get the param_groups of the wrapped optimizer)
+        # In this case, state_dict['state'] is empty.
+        if state['state']:
+            new_param_states = {}
+            for flat_idx, (fpi, param_indices) in self._flat_map.items():
+                if fpi is None:
+                    assert len(param_indices) == 1
+                    if param_indices[0] in state['state']:
+                        new_param_states[flat_idx] = state['state'][param_indices[0]]
+                elif any(i in state['state'] for i in param_indices):
+                    # need to flatten the states
+                    embeded_states = [
+                        state['state'][i]['momentum_buffer'] if i in state['state'] else None
+                        for i in param_indices
+                    ]
+                    new_param_states[flat_idx] = {'momentum_buffer': fpi.flatten(embeded_states, device='cpu')}
+                #else: no state for this flattened param
+
+            state['state'] = new_param_states
+
+        state['param_groups'][0]['params'] = list(range(len(self._flat_map)))
+        return state
+
+    def load_state_dict(self, state_dict: OptStateDict):
+        """
+        Override load_state_dict to unflatten the states
+        This is necessary to be compatible with other state dict related functions
+        such as merge_state_dict
+        """
+        new_param_states = {}
+        for flat_idx, (fpi, param_indices) in self._flat_map.items():
+            if flat_idx not in state_dict['state']:
+                continue
+            if fpi is None:
+                assert len(param_indices) == 1
+                new_param_states[param_indices[0]] = state_dict['state'][flat_idx]
+            else:
+                # need to unflatten the states
+                flat_state = state_dict['state'][flat_idx]['momentum_buffer']
+                embeded_states = fpi.unflatten(flat_state, device='cpu')
+                for i, param_idx in enumerate(param_indices):
+                    new_param_states[param_idx] = {'momentum_buffer': embeded_states[i]}
+        state_dict['state'] = new_param_states
+        param_count = sum(len(v[1]) for v in self._flat_map.values())
+        state_dict['param_groups'][0]['params'] = list(range(param_count))
+        super().load_state_dict(state_dict)
+
+
+if torch.__version__ >= (2, 9, 0):
+    from torch.optim import Muon as _Muon
+
+    class Muon(MuonMixin, _Muon):
+        pass

--- a/nnscaler/runtime/utils.py
+++ b/nnscaler/runtime/utils.py
@@ -3,9 +3,16 @@
 
 r"""Runtime Utilities"""
 
-from typing import Any, List
+from typing import Any, List, TYPE_CHECKING, Optional
 import logging
 import heapq
+
+import torch
+
+if TYPE_CHECKING:
+    from nnscaler.runtime.adapter.reducer import FlattenParamInfo
+    from nnscaler.runtime.module import AttrMeta
+
 
 _logger = logging.getLogger(__name__)
 
@@ -227,3 +234,51 @@ def _split_array_min_max_out_of_order(nums: list[int], g: int) -> tuple[list[lis
         heapq.heappush(heap, (new_sum, gidx))
 
     return groups, group_idx
+
+
+FLATTEN_META_KEY = '__nnscaler_flattened_meta__'
+DISTRIBUTED_PARAM_META_KEY = '__nnscaler_distributed_meta__'
+
+
+def is_fparam(param: torch.nn.Parameter) -> bool:
+    """
+    Check if a parameter is a flattened parameter.
+    """
+    return hasattr(param, FLATTEN_META_KEY)
+
+
+def get_fparam_meta(param: torch.nn.Parameter) -> Optional['FlattenParamInfo']:
+    """
+    Get the meta information of a flattened parameter.
+    None if the parameter is not a flattened parameter.
+    """
+    return getattr(param, FLATTEN_META_KEY, None)
+
+
+def set_fparam_meta(param: torch.nn.Parameter, meta: 'FlattenParamInfo'):
+    """
+    Set the meta information of a flattened parameter.
+    """
+    setattr(param, FLATTEN_META_KEY, meta)
+
+
+def is_dparam(param: torch.nn.Parameter) -> bool:
+    """
+    Check if a parameter is a distributed parameter.
+    """
+    return hasattr(param, DISTRIBUTED_PARAM_META_KEY)
+
+
+def get_dparam_meta(param: torch.nn.Parameter) -> Optional['AttrMeta']:
+    """
+    Get the distributed meta information of a parameter.
+    None if the parameter does not have distributed meta.
+    """
+    return getattr(param, DISTRIBUTED_PARAM_META_KEY, None)
+
+
+def set_dparam_meta(param: torch.nn.Parameter, meta: 'AttrMeta'):
+    """
+    Set the distributed meta information of a parameter.
+    """
+    setattr(param, DISTRIBUTED_PARAM_META_KEY, meta)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ mock
 myst-parser
 pre-commit
 pytest
-pytest-cov
+pytest-cov<7.0.0
 pytest-mock
 scikit-learn
 lightning==2.5.1.post0

--- a/tests/cli/common.py
+++ b/tests/cli/common.py
@@ -200,3 +200,25 @@ class SimpleIterDataset(StreamingDataset):
                 'data': torch.tensor(item['data']),
                 'target': torch.tensor(item['target'])
             }
+
+
+class MLP2(nn.Module):
+    def __init__(self, input_dim: int, feature_dim: int, output_dim: int, nlayers: int):
+        init_random_fn()
+        super().__init__()
+        self.input_proj = nn.Linear(input_dim, feature_dim, bias=False)
+        self.layers = torch.nn.ModuleList([])
+        for _ in range(nlayers):
+            self.layers.append(nn.Linear(feature_dim, feature_dim, bias=False))
+        self.output_proj = nn.Linear(feature_dim, output_dim, bias=False)
+        self.loss_fn = nn.BCELoss()
+
+    def forward(self, data: Dict[str, torch.Tensor]):
+        x = data['data']
+        x = self.input_proj(x)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.output_proj(x)
+        x = torch.sigmoid(x)
+        loss = self.loss_fn(x, data['target'])
+        return loss

--- a/tests/cli/test_trainer.py
+++ b/tests/cli/test_trainer.py
@@ -637,6 +637,7 @@ def trainer_correctness_worker(save_dir, parallel_type=0, async_reducer=False, h
     config_path = str(Path(__file__).with_name('trainer_args.yaml').resolve())
     gen_savedir = save_dir / 'gen'
     ckpt_savedir = save_dir / 'ckpt'
+    instance_name = f'pt_parallel_type{parallel_type}_async{async_reducer}_hybrid{hybrid_opt}_usezero{use_zero}_zpls{zero_param_level_sharding}_reducercap{int(reducer_bucket_cap_mb)}'
 
     if parallel_type == 0:
         # parallelize the whole MixedModule
@@ -742,6 +743,7 @@ def trainer_correctness_worker(save_dir, parallel_type=0, async_reducer=False, h
     # train 4 epcho in one time
     trainer = Trainer([
         '-f', config_path,
+        '--instance_name', instance_name,
         '--precision', 'fp32',
         '--max_epochs', '2',
         '--enable_progress_bar', 'false',

--- a/tests/cli/test_trainer_muon.py
+++ b/tests/cli/test_trainer_muon.py
@@ -17,27 +17,13 @@ except ImportError:
 
 
 
-def trainer_muon_worker(save_dir, config_file, zero=False):
+def trainer_muon_worker(save_dir, config_file, name, additional_options=None):
     save_dir = Path(save_dir)
     config_path = Path(__file__).with_name(config_file).resolve()
-    work_dir = save_dir / str(zero)
+    work_dir = save_dir / str(name)
     gen_savedir = work_dir / 'gen'
     ckpt_savedir = work_dir / 'ckpt'
-
-    zero_options = []
-    if zero:
-        zero_options = [
-            '--compute_config.zero_param_level_sharding', True,
-            '--compute_config.use_zero', 1,
-        ]
-        if 'hybrid' in config_file:
-            zero_options += [
-                '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
-            ]
-        else:
-            zero_options += [
-                '--optimizer.type', 'nnscaler.runtime.muon_optimizer.Muon',
-            ]
+    additional_options = additional_options or []
 
     # train first epoch
     trainer = Trainer([
@@ -45,7 +31,7 @@ def trainer_muon_worker(save_dir, config_file, zero=False):
         '--max_epochs', '1',
         '--gen_savedir', str(gen_savedir),
         '--checkpoint.save_dir', str(ckpt_savedir),
-        *zero_options,
+        *additional_options,
     ])
     trainer.run()
     torch.distributed.barrier()
@@ -63,7 +49,7 @@ def trainer_muon_worker(save_dir, config_file, zero=False):
         '--gen_savedir', str(gen_savedir),
         '--checkpoint.save_dir', str(ckpt_savedir),
         '--checkpoint.resume_from', str(ckpt_savedir / 'merged.pt'),
-        *zero_options,
+        *additional_options,
     ])
     trainer.run()
 
@@ -77,7 +63,7 @@ def trainer_muon_worker(save_dir, config_file, zero=False):
         '--checkpoint.save_dir', str(ckpt_savedir),
         '--checkpoint.resume_from', 'last',
         '--checkpoint.save_type', 'sharded',
-        *zero_options,
+        *additional_options,
     ])
     trainer.run()
 
@@ -90,7 +76,7 @@ def trainer_muon_worker(save_dir, config_file, zero=False):
         '--gen_savedir', str(gen_savedir),
         '--checkpoint.save_dir', str(ckpt_savedir),
         '--checkpoint.resume_from', 'last',
-        *zero_options,
+        *additional_options,
     ])
     trainer.run()
 
@@ -103,7 +89,7 @@ def trainer_muon_worker(save_dir, config_file, zero=False):
         '--max_epochs', '4',
         '--gen_savedir', str(gen_savedir),
         '--checkpoint.save_dir', str(ckpt1_savedir),
-        *zero_options,
+        *additional_options,
     ])
     trainer.run()
 
@@ -123,10 +109,14 @@ def trainer_muon_worker(save_dir, config_file, zero=False):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason='lack of gpu devices')
-@pytest.mark.parametrize('config_file', ['trainer_args_muon.yaml', 'trainer_args_muon_hybrid.yaml'])
-def test_trainer_muon_resume_correctness(tmp_path, config_file):
-    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, False)
-    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, True)
+def test_trainer_muon_resume_correctness1(tmp_path):
+    config_file = 'trainer_args_muon.yaml'
+    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, 'False')
+    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, 'True', [
+        '--compute_config.zero_param_level_sharding', True,
+        '--compute_config.use_zero', 1,
+        '--optimizer.type', 'nnscaler.runtime.muon_optimizer.Muon',
+    ])
 
     zero0_ckpt = torch.load(tmp_path / 'False' / 'result.pt', weights_only=False)
     zero1_ckpt = torch.load(tmp_path / 'True' / 'result.pt', weights_only=False)
@@ -135,11 +125,46 @@ def test_trainer_muon_resume_correctness(tmp_path, config_file):
     assert_equal(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
 
 
+@pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason='lack of gpu devices')
+def test_trainer_muon_resume_correctness2(tmp_path):
+    config_file = 'trainer_args_muon_hybrid.yaml'
+    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, '1')
+    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, '2', [
+        '--compute_config.zero_param_level_sharding', True,
+        '--compute_config.use_zero', 1,
+        '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
+    ])
+    launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, '3', [
+        '--compute_config.use_zero', 1,
+        '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
+        '--optimizer.param_clss_fn', 'tests.cli.test_trainer_muon.param_clss_fn2',
+    ])
+
+    zero0_ckpt = torch.load(tmp_path / '1' / 'result.pt', weights_only=False)
+    zero1_ckpt = torch.load(tmp_path / '2' / 'result.pt', weights_only=False)
+    zero2_ckpt = torch.load(tmp_path / '3' / 'result.pt', weights_only=False)
+
+    assert_equal(zero0_ckpt['model'], zero1_ckpt['model'])
+    assert_equal(zero0_ckpt['model'], zero2_ckpt['model'])
+    assert_equal(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
+    assert_equal(zero0_ckpt['optimizer']['state'], zero2_ckpt['optimizer']['state'])
+
+
 def param_clss_fn(param_name: str) -> tuple[int, int]:
     """
     Classify a parameter name into an optimizer index and a parameter group index.
     """
-    if 'layers.1.' in param_name or 'layers.10.' in param_name:
+    if 'layers.1.' in param_name or 'layers.10.' in param_name or 'layers.2.' in param_name:
         return 0, 0
     else:
         return 1, 0
+
+
+def param_clss_fn2(param_name: str) -> tuple[int, int]:
+    """
+    Classify a parameter name into an optimizer index and a parameter group index.
+    """
+    if 'layers.1.' in param_name or 'layers.10.' in param_name or 'layers.2.' in param_name:
+        return 0, 0, {'zero_param_level_sharding': None}
+    else:
+        return 1, 0, {'zero_param_level_sharding': True}

--- a/tests/cli/test_trainer_muon.py
+++ b/tests/cli/test_trainer_muon.py
@@ -206,15 +206,17 @@ def test_trainer_muon_resume_correctness_zero_ngroups(tmp_path):
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 4, reason='lack of gpu devices')
 def test_trainer_muon_resume_correctness_zero_ngroups_hybrid_param_config(tmp_path):
     config_file = 'trainer_args_muon_hybrid.yaml'
-    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '2', [
+
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '1', [
         '--compute_config.use_zero', 1,
-        '--compute_config.zero_ngroups', 2,
         '--compute_config.runtime_ngpus', 4,
         '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
         '--optimizer.param_clss_fn', 'tests.cli.test_trainer_muon.param_clss_fn2',
     ])
-    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '1', [
+
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '2', [
         '--compute_config.use_zero', 1,
+        '--compute_config.zero_ngroups', 2,
         '--compute_config.runtime_ngpus', 4,
         '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
         '--optimizer.param_clss_fn', 'tests.cli.test_trainer_muon.param_clss_fn2',

--- a/tests/cli/test_trainer_muon.py
+++ b/tests/cli/test_trainer_muon.py
@@ -7,7 +7,7 @@ import pytest
 
 from nnscaler.cli.trainer import Trainer
 from tests.launch_torchrun import launch_torchrun
-from tests.parallel_module.common import assert_equal
+from tests.parallel_module.common import assert_close, assert_equal
 
 
 try:
@@ -109,7 +109,7 @@ def trainer_muon_worker(save_dir, config_file, name, additional_options=None):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason='lack of gpu devices')
-def test_trainer_muon_resume_correctness1(tmp_path):
+def test_trainer_muon_resume_correctness_basic(tmp_path):
     config_file = 'trainer_args_muon.yaml'
     launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, 'False')
     launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, 'True', [
@@ -125,8 +125,31 @@ def test_trainer_muon_resume_correctness1(tmp_path):
     assert_equal(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
 
 
+@pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 4, reason='lack of gpu devices')
+def test_trainer_muon_resume_correctness_zero1(tmp_path):
+    config_file = 'trainer_args_muon.yaml'
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '1', [
+        '--compute_config.zero_param_level_sharding', True,
+        '--compute_config.runtime_ngpus', 4,
+        '--compute_config.use_zero', 1,
+        '--optimizer.type', 'nnscaler.runtime.muon_optimizer.Muon',
+    ])
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '2', [
+        '--compute_config.zero_param_level_sharding', True,
+        '--compute_config.runtime_ngpus', 4,
+        '--compute_config.use_zero', 0,
+        '--optimizer.type', 'nnscaler.runtime.muon_optimizer.Muon',
+    ])
+
+    zero0_ckpt = torch.load(tmp_path / '1' / 'result.pt', weights_only=False)
+    zero1_ckpt = torch.load(tmp_path / '2' / 'result.pt', weights_only=False)
+
+    assert_equal(zero0_ckpt['model'], zero1_ckpt['model'])
+    assert_equal(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
+
+
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason='lack of gpu devices')
-def test_trainer_muon_resume_correctness2(tmp_path):
+def test_trainer_muon_resume_correctness_zero1_param_config(tmp_path):
     config_file = 'trainer_args_muon_hybrid.yaml'
     launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, '1')
     launch_torchrun(2, trainer_muon_worker, tmp_path, config_file, '2', [
@@ -148,6 +171,60 @@ def test_trainer_muon_resume_correctness2(tmp_path):
     assert_equal(zero0_ckpt['model'], zero2_ckpt['model'])
     assert_equal(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
     assert_equal(zero0_ckpt['optimizer']['state'], zero2_ckpt['optimizer']['state'])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 4, reason='lack of gpu devices')
+def test_trainer_muon_resume_correctness_zero_ngroups(tmp_path):
+    config_file = 'trainer_args_muon.yaml'
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '1',  [
+        '--compute_config.zero_param_level_sharding', True,
+        '--compute_config.use_zero', 1,
+        '--compute_config.runtime_ngpus', 4,
+        '--optimizer.type', 'nnscaler.runtime.muon_optimizer.Muon',
+    ])
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '2',  [
+        '--compute_config.runtime_ngpus', 4,
+    ])
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '3', [
+        '--compute_config.zero_param_level_sharding', True,
+        '--compute_config.use_zero', 1,
+        '--compute_config.zero_ngroups', 2,
+        '--compute_config.runtime_ngpus', 4,
+        '--optimizer.type', 'nnscaler.runtime.muon_optimizer.Muon',
+    ])
+
+    zero0_ckpt = torch.load(tmp_path / '1' / 'result.pt', weights_only=False)
+    zero1_ckpt = torch.load(tmp_path / '2' / 'result.pt', weights_only=False)
+    zero2_ckpt = torch.load(tmp_path / '3' / 'result.pt', weights_only=False)
+
+    assert_equal(zero0_ckpt['model'], zero1_ckpt['model'])
+    assert_equal(zero0_ckpt['model'], zero2_ckpt['model'])
+    assert_equal(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
+    assert_equal(zero0_ckpt['optimizer']['state'], zero2_ckpt['optimizer']['state'])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 4, reason='lack of gpu devices')
+def test_trainer_muon_resume_correctness_zero_ngroups_hybrid_param_config(tmp_path):
+    config_file = 'trainer_args_muon_hybrid.yaml'
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '2', [
+        '--compute_config.use_zero', 1,
+        '--compute_config.zero_ngroups', 2,
+        '--compute_config.runtime_ngpus', 4,
+        '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
+        '--optimizer.param_clss_fn', 'tests.cli.test_trainer_muon.param_clss_fn2',
+    ])
+    launch_torchrun(4, trainer_muon_worker, tmp_path, config_file, '1', [
+        '--compute_config.use_zero', 1,
+        '--compute_config.runtime_ngpus', 4,
+        '--optimizer.args.config.optimizers.1.type', 'nnscaler.runtime.muon_optimizer.Muon',
+        '--optimizer.param_clss_fn', 'tests.cli.test_trainer_muon.param_clss_fn2',
+    ])
+
+    zero0_ckpt = torch.load(tmp_path / '1' / 'result.pt', weights_only=False)
+    zero1_ckpt = torch.load(tmp_path / '2' / 'result.pt', weights_only=False)
+
+    assert_close(zero0_ckpt['model'], zero1_ckpt['model'])
+    assert_close(zero0_ckpt['optimizer']['state'], zero1_ckpt['optimizer']['state'])
 
 
 def param_clss_fn(param_name: str) -> tuple[int, int]:

--- a/tests/cli/trainer_args_muon_hybrid.yaml
+++ b/tests/cli/trainer_args_muon_hybrid.yaml
@@ -20,9 +20,11 @@ precision: fp32
 enable_progress_bar: false
 
 model:
-  type: tests.cli.common.MLP
+  type: tests.cli.common.MLP2
   args:
-    dim: $(vars.dim)
+    input_dim: $(vars.dim)
+    feature_dim: 24
+    output_dim: $(vars.dim)
     nlayers: 16
 
 

--- a/tests/cli/trainer_args_muon_hybrid.yaml
+++ b/tests/cli/trainer_args_muon_hybrid.yaml
@@ -16,7 +16,7 @@ global_batch_size: 8
 max_epochs: 4
 max_train_steps: 100
 seed: 0
-precision: bf16
+precision: fp32
 enable_progress_bar: false
 
 model:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,10 +31,12 @@ def clean_generated_files():
         f.unlink()
 
 
-def pytest_collection_modifyitems(session, config, items):
-    def policy_first(item):
-        # it is very easy to break policy related tests, so run them first
+def pytest_collection_modifyitems(session, config, items: list[pytest.Function]):
+    def policy_first(item: pytest.Function):
+        # it is very easy to break the following tests, so run them first
         if item.fspath.basename == 'test_policies.py':
             return 0
-        return 1
+        if item.fspath.basename == 'test_trainer.py':
+            return 1
+        return 2
     items.sort(key=policy_first)

--- a/tests/parallel_module/common.py
+++ b/tests/parallel_module/common.py
@@ -133,11 +133,11 @@ def assert_equal(a: Any, b: Any):
     if isinstance(a, torch.Tensor):
         assert torch.equal(a.cpu(), b.cpu()), torch.max(torch.abs(a.cpu() - b.cpu()))
     elif isinstance(a, dict):
-        assert len(a) == len(b)
+        assert len(a) == len(b), (a.keys(), b.keys())
         for k in a.keys():
             assert_equal(a[k], b[k])
     elif isinstance(a, (list, tuple)):
-        assert len(a) == len(b)
+        assert len(a) == len(b), (a, b)
         for i in range(len(a)):
             assert_equal(a[i], b[i])
     else:
@@ -149,11 +149,11 @@ def assert_close(a: Any, b: Any, atol=1e-6, rtol=1e-6):
     if isinstance(a, torch.Tensor):
         assert torch.allclose(a.cpu(), b.cpu(), atol=atol, rtol=rtol)
     elif isinstance(a, dict):
-        assert len(a) == len(b)
+        assert len(a) == len(b), (a.keys(), b.keys())
         for k in a.keys():
             assert_close(a[k], b[k], atol=atol, rtol=rtol)
     elif isinstance(a, (list, tuple)):
-        assert len(a) == len(b)
+        assert len(a) == len(b), (a, b)
         for i in range(len(a)):
             assert_close(a[i], b[i], atol=atol, rtol=rtol)
     else:

--- a/tests/parallel_module/test_checkpoint.py
+++ b/tests/parallel_module/test_checkpoint.py
@@ -636,7 +636,7 @@ def _gather_full_model_state_dict_worker(tmp_path, use_zero):
     torch.distributed.barrier()
     merged_state_dict = merge_state_dicts(
         [torch.load(tmp_path / f'{i}.pt', weights_only=False) for i in range(torch.distributed.get_world_size())]
-    )
+    )[0]
     full_state_dict = gather_full_model_state_dict(model)
     assert_equal(merged_state_dict, full_state_dict)
 


### PR DESCRIPTION
1. add a new flag `zero_param_level_sharding` so user can control the granularity of sharding parameters in ZeRO
2. Add a muon mixin to flatten/unflatten parameters for Muon.
3. Refine logic for flatten buffers. We will record the position (start/end) of each paraemters in the flattened buffer. (instead of calculating it on the fly). So we have more freedom to add paddings.