### PR TITLE
[Runtime]  Refine the performance of module state dict gathering for tensor parallelism

### DIFF
--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -3320,17 +3320,63 @@ def load_merged_state_dict_from_rank(
 @torch.no_grad()
 def gather_full_model_state_dict(
     module: torch.nn.Module,
+    *,
+    device: Union[str, torch.device] = None,
 ) -> Dict[str, Any]:
     """
-    Gather model state dicts from all ranks,
-    And merge them into a single merged model state dict in all ranks.
+    Gather model state dicts from all ranks for all ranks.
+    It will firstly try to use a fast way (only support tp with zero0/zero1)
+        to gather the state dicts,
+        and if it fails, it will fallback to the naive gather/merge/broadcast approach.
 
     Args:
         module (torch.nn.Module): the module to gather state dicts from
+        device: the device to put the merged state dict.
+            Use torch.cuda.current_device() if it is None.
 
     Returns:
         Dict[str, Any]: the merged model state dict
     """
+    device = device or torch.cuda.current_device()
+
+    merged_state_dict = {}
+    for module_path, module in module.named_modules():
+        if not isinstance(module, ParallelModule):
+            state_dict = module.state_dict()
+        else:
+            try:
+                state_dict = module.gather_state_dict(device=device)
+            except Exception as e:
+                logger.warning(f'Failed to gather parallel module {module.__class__.__name__} at `{module_path}`, Fallback to naive implementation.'
+                               f'\nError: {e}')
+                state_dict = _gather_full_model_state_dict(module, device=device)
+
+        for key, value in state_dict.items():
+            merged_state_dict[f'{module_path}.{key}' if module_path else key] = value.to(device, non_blocking=True)
+
+    torch.cuda.synchronize()
+
+    return merged_state_dict
+
+
+@torch.no_grad()
+def _gather_full_model_state_dict(
+    module: torch.nn.Module,
+    *,
+    device=None,
+) -> Dict[str, Any]:
+    """
+    Gather model state dicts from all ranks using naive gather/merge/broadcast approach.
+
+    Args:
+        module (torch.nn.Module): the module to gather state dicts from
+        device: the device to put the merged state dict.
+            Use torch.cuda.current_device() if it is None.
+
+    Returns:
+        Dict[str, Any]: the merged model state dict
+    """
+    device = device or torch.cuda.current_device()
 
     rank = torch.distributed.get_rank()
     parallel_modules = [m for m in module.modules() if isinstance(m, ParallelModule)]
@@ -3346,7 +3392,7 @@ def gather_full_model_state_dict(
     if rank < num_involved_ranks:
         local_state_dict, _ = deduped_state_dict(module, optimizer=None)
         logger.info(f'Rank {rank}: gathering state dict')
-        state_dicts = gather_mixed_data(local_state_dict, src_rank=0, group=involved_group, device='cpu')
+        state_dicts = gather_mixed_data(local_state_dict, src_rank=0, group=involved_group, device=device)
         if rank == 0:
             logger.info(f'Rank {rank}: merging gathered state dicts')
             merge_state_dict = merge_state_dicts(state_dicts)[0]
@@ -3356,7 +3402,7 @@ def gather_full_model_state_dict(
         merge_state_dict = None
 
     logger.info(f'Rank {rank}: Broadcasting merged state dict to all ranks')
-    merge_state_dict = broadcast_mixed_data(merge_state_dict, src_rank=0, device='cpu')
+    merge_state_dict = broadcast_mixed_data(merge_state_dict, src_rank=0, device=device)
     logger.info(f'Rank {rank}: Finished gathering full model state dict')
     torch.distributed.barrier()
     return merge_state_dict

--- a/nnscaler/runtime/module.py
+++ b/nnscaler/runtime/module.py
@@ -60,6 +60,13 @@ class AttrMeta:
     # it should be the shape of full_tensor[slicers]
     sub_shape: Tuple[int, ...]
 
+    def get_partitioned_dims(self):
+        partitioned_dims = []
+        for dim, (sub, orig) in enumerate(zip(self.sub_shape, self.shape)):
+            if sub != orig:
+                partitioned_dims.append(dim)
+        return partitioned_dims
+
 
 @dataclass
 class Zero3AttrMeta:
@@ -1759,6 +1766,100 @@ class ParallelModule(CubeModule):
                             trimmed_state_dict[prefix + attr] = content.reshape(-1)[start:end].to(device)
 
         return trimmed_state_dict
+
+    @torch.no_grad()
+    def gather_state_dict(
+        self,
+        *,
+        device: Union[str, torch.device] = None,
+    ) -> Dict[str, Any]:
+        """
+        Gather model state dicts from all ranks involved in the parallel module,
+        And merge them into a single merged model state dict in all ranks.
+
+        TODO: More general implementation for more complex partitioning strategy
+        (e.g. pipeline parallelism, zero3, partition on multiple dimensions, uneven partition),
+        currently we only support single-dimension even partition.
+
+        Args:
+            device: the device to put the merged state dict.
+                Use torch.cuda.current_device() if it is None.
+        Returns:
+            Dict[str, Any]: the merged model state dict
+        """
+        if self.compute_config.use_zero > 1:
+            raise ValueError("Zero3 is not supported.")
+
+        device = device or torch.cuda.current_device()
+        rank = torch.distributed.get_rank()
+        compute_config = self.compute_config
+
+        # dg -> dedup group
+        dg_size = compute_config.module_dedup_group_size
+        dg_index = torch.distributed.get_rank() // dg_size
+        dg_ranks = list(range(dg_index * dg_size, (dg_index + 1) * dg_size))
+
+        attr_metas = [self.get_attr_meta_map(rank) for rank in dg_ranks]
+        # key: orig attr name,
+        # value: list of (local attr name, attr meta) for each rank in the dedup group
+        attr_pas: dict[str, list[tuple[str, AttrMeta]]] = {}
+        for rank, attr_meta in enumerate(attr_metas):
+            for attr_name, meta in attr_meta.items():
+                if meta.orig_name not in attr_pas:
+                    attr_pas[meta.orig_name] = [None] * dg_size
+                attr_pas[meta.orig_name][rank] = (attr_name, meta)
+
+        # verify we can handle this module
+        for key, pas in attr_pas.items():
+            metas = [pa[1] for pa in pas]
+            if any(meta is None for meta in metas):
+                raise ValueError(f'Attribute {key} is missing in some ranks: {metas}. NOTE: Pipeline Parallelism is not supported.')
+
+            if not all(meta.sub_shape == metas[0].sub_shape for meta in metas):
+                raise ValueError(f'Attribute {key} has inconsistent sub shapes across ranks: {metas}.')
+
+            partitioned_dims = metas[0].get_partitioned_dims()
+            if len(partitioned_dims) > 1:
+                raise ValueError(f'Attribute {key} is partitioned on multiple dimensions: {metas}. NOTE: Only single-dimension partition is supported.')
+
+        _logger.info(f'Rank {rank}: Gathering model state dict from ranks {dg_ranks} for parallel module {self.__class__.__name__}')
+
+        dedup_group = DeviceGroup().get_group(dg_ranks)
+        dg_rank = torch.distributed.get_rank(dedup_group)
+
+        state_dict: dict[str, torch.Tensor] = self.state_dict()
+        merged_state_dict = {}
+        for key, pas in attr_pas.items():
+            metas = [pa[1] for pa in pas]
+            # Skip non-persistent buffers (e.g. rope_cos_sin_cache) that appear in
+            # attr_meta_map but are not included in state_dict.
+            if pas[dg_rank][0] not in state_dict:
+                _logger.debug(f'Rank {rank}: Skipping attribute {key} (local name {pas[dg_rank][0]}) — not in state_dict (likely a non-persistent buffer).')
+                continue
+
+            partitioned_dims = metas[0].get_partitioned_dims()
+            if not partitioned_dims: # replicated tensor, just take from state dict
+                merged_state_dict[key] = state_dict[pas[dg_rank][0]].to(device, non_blocking=True)
+            else:
+                # partitioned tensor, need to all gather
+                # Use GPU for the collective, then immediately move to target device
+                # and delete GPU temporaries to keep peak memory low.
+                local_tensor = state_dict[pas[dg_rank][0]].cuda()
+                dest = [
+                    torch.empty(metas[0].sub_shape, dtype=metas[0].dtype, device='cuda')
+                    for _ in metas
+                ]
+                # all_gather_into_tensor is not used here
+                # because the partitioned dimension may not be the first dimension,
+                # and all_gather_into_tensor only supports gathering on the first dimension.
+                torch.distributed.all_gather(dest, local_tensor, group=dedup_group)
+                merged_state_dict[key] = torch.cat(dest, dim=partitioned_dims[0]).to(device, non_blocking=True)
+                del dest, local_tensor
+
+        _logger.info(f'Rank {rank}: Finished gathering model state dict')
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+        return merged_state_dict
 
     def _pack(
         self,

--- a/tests/parallel_module/test_checkpoint.py
+++ b/tests/parallel_module/test_checkpoint.py
@@ -30,7 +30,7 @@ from nnscaler.runtime.gnorm import calcuate_gnorm
 
 from .common import CubeLinear, init_random, init_distributed, PASMegatron, assert_equal
 from ..launch_torchrun import launch_torchrun, clone_to_cpu_recursively
-from ..utils import replace_all_device_with, clear_dir_on_rank0, PYTEST_RUN_ID
+from ..utils import replace_all_device_with, clear_dir_on_rank0, PYTEST_RUN_ID, catch_log
 
 
 class FcRelu(nn.Module):
@@ -615,7 +615,8 @@ def test_checkpoint_merge():
 
 def _gather_full_model_state_dict_worker(tmp_path, use_zero):
     from .test_end2end import MLP, dummy_data
-    from nnscaler.parallel import gather_full_model_state_dict, merge_state_dicts
+    from nnscaler.parallel import gather_full_model_state_dict, merge_state_dicts, _gather_full_model_state_dict
+    from nnscaler.parallel import logger as p_logger
     init_distributed()
 
     model = MLP()
@@ -637,8 +638,24 @@ def _gather_full_model_state_dict_worker(tmp_path, use_zero):
     merged_state_dict = merge_state_dicts(
         [torch.load(tmp_path / f'{i}.pt', weights_only=False) for i in range(torch.distributed.get_world_size())]
     )[0]
-    full_state_dict = gather_full_model_state_dict(model)
-    assert_equal(merged_state_dict, full_state_dict)
+
+    if use_zero > 1:
+        with catch_log(p_logger, 'WARNING') as logs:
+            full_state_dict = gather_full_model_state_dict(model)
+        assert 'Zero3 is not supported.' in logs.getvalue()
+        assert_equal(merged_state_dict, full_state_dict)
+        with pytest.raises(ValueError):
+             model.gather_state_dict()
+    else:
+        with catch_log(p_logger, 'WARNING') as logs:
+            full_state_dict = gather_full_model_state_dict(model)
+        assert 'Failed to gather parallel module' not in logs.getvalue()
+        assert_equal(merged_state_dict, full_state_dict)
+        f1 = model.gather_state_dict()
+        assert_equal(merged_state_dict, f1)
+
+    f2 = _gather_full_model_state_dict(model)
+    assert_equal(merged_state_dict, f2)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 4, reason='lack of gpu devices')


### PR DESCRIPTION
1. try to use `all_gather` to gather weights from other ranks for TP
2. If fails (pp/zero3 are used), we will fallback to use the old way.