### PR TITLE
[Bugfix] Fix multiref handling for pipeline parallelism

### DIFF
--- a/nnscaler/autodist/apis.py
+++ b/nnscaler/autodist/apis.py
@@ -156,7 +156,17 @@ def parallelize_graph(graph: IRGraph,
         # For safety, we will add multiref when detecting shared param are all replicated for pipeline parallelism.
         # The reason is that stages may have different number of devices, it is hard to synchronize gradients directly
         # by inserting reducers although weights are all REPLICAED.
-        if len(splits) > 1 or (len(pp_desc.spmd_descs) > 1 and find_replicated):
+
+        # A further exlanation:
+        # 1. len(splits) > 1: the param is partitioned in different ways in its different consumers.
+        #    this can also happen when pipeline parallelism is not used
+        #    this `multiref` is necessary to make gen_weight happy (see `IRAdapterGener.gen_weight` in `nnscaler/graph/gener/gen.py`)
+        # 2. len(stage_info) > 1: the param is shared across stages
+        # 3. find_replicated: is replicated in at least one stage.
+        # 4. (2) and (3): if the param is shared across stages and is all replicated in all stages
+        #    Note: the case when some is replicated and some is partitioned is handled by (1).
+
+        if len(splits) > 1 or (len(stage_info) > 1 and find_replicated):
             _logger.info(f'add multiref for shared param {ftensor}')
             graph.multiref(ftensor, comment='shared param')
 

--- a/nnscaler/autodist/apis.py
+++ b/nnscaler/autodist/apis.py
@@ -157,13 +157,13 @@ def parallelize_graph(graph: IRGraph,
         # The reason is that stages may have different number of devices, it is hard to synchronize gradients directly
         # by inserting reducers although weights are all REPLICAED.
 
-        # A further exlanation:
+        # A further explanation:
         # 1. len(splits) > 1: the param is partitioned in different ways in its different consumers.
         #    this can also happen when pipeline parallelism is not used
         #    this `multiref` is necessary to make gen_weight happy (see `IRAdapterGener.gen_weight` in `nnscaler/graph/gener/gen.py`)
         # 2. len(stage_info) > 1: the param is shared across stages
         # 3. find_replicated: is replicated in at least one stage.
-        # 4. (2) and (3): if the param is shared across stages and is all replicated in all stages
+        # 4. (2) and (3): the param is shared across stages and is replicated in at least one of them.
         #    Note: the case when some is replicated and some is partitioned is handled by (1).
 
         if len(splits) > 1 or (len(stage_info) > 1 and find_replicated):

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -753,7 +753,17 @@ def fn(
         # For safety, we will add multiref when detecting shared param are all replicated for pipeline parallelism.
         # The reason is that stages may have different number of devices, it is hard to synchronize gradients directly
         # by inserting reducers although weights are all REPLICAED.
-        if len(splits) > 1 or (pp_enabled and find_replicated):
+
+        # A further exlanation:
+        # 1. len(splits) > 1: the param is partitioned in different ways in its different consumers.
+        #    this can also happen when pipeline parallelism is not used
+        #    this `multiref` is necessary to make gen_weight happy (see `IRAdapterGener.gen_weight` in `nnscaler/graph/gener/gen.py`)
+        # 2. len(stage_info) > 1: the param is shared across stages
+        # 3. find_replicated: is replicated in at least one stage.
+        # 4. (2) and (3): if the param is shared across stages and is all replicated in all stages
+        #    Note: the case when some is replicated and some is partitioned is handled by (1).
+
+        if len(splits) > 1 or (len(stage_info) > 1 and find_replicated):
             _logger.info(f'add multiref for shared param {ftensor}')
             graph.multiref(ftensor, comment='shared param')
 

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -754,13 +754,13 @@ def fn(
         # The reason is that stages may have different number of devices, it is hard to synchronize gradients directly
         # by inserting reducers although weights are all REPLICAED.
 
-        # A further exlanation:
+        # A further explanation:
         # 1. len(splits) > 1: the param is partitioned in different ways in its different consumers.
         #    this can also happen when pipeline parallelism is not used
         #    this `multiref` is necessary to make gen_weight happy (see `IRAdapterGener.gen_weight` in `nnscaler/graph/gener/gen.py`)
         # 2. len(stage_info) > 1: the param is shared across stages
         # 3. find_replicated: is replicated in at least one stage.
-        # 4. (2) and (3): if the param is shared across stages and is all replicated in all stages
+        # 4. (2) and (3): if the param is shared across stages and is replicated in at least one stage.
         #    Note: the case when some is replicated and some is partitioned is handled by (1).
 
         if len(splits) > 1 or (len(stage_info) > 1 and find_replicated):

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -429,6 +429,7 @@ def test_codegen_fn_pipeline(tmp_path):
 class FnPolicyModuleSharedWeight(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.pre_input_projection = torch.nn.Linear(4, 4, bias=False)
         self.input_projection = torch.nn.Linear(4, 4, bias=False)
         self.ffn = torch.nn.ModuleList([
             FFNDropout(4, 8),
@@ -438,12 +439,12 @@ class FnPolicyModuleSharedWeight(torch.nn.Module):
         self.output_projection.weight = self.input_projection.weight  # share weight
 
     def forward(self, x):
+        x = self.pre_input_projection(x)
         x = self.input_projection(x)
         for ffn in self.ffn:
             x = ffn(x)
         x = self.output_projection(x)
         return torch.sum(x) # make sure output is scalar loss (required by pipeline parallelism)
-
 
 
 @replace_all_device_with('cpu')
@@ -465,6 +466,8 @@ def test_codegen_fn_pipeline_shared_weight(tmp_path):
     for rank in range(2):
         # the input projection is multiref'ed
         assert _gencode_contains(tmp_path, FnPolicyModuleSharedWeight, rank, r'nnscaler.runtime.function.multiref\(self.input_projection')
+        # pre_input_projection is not multiref'ed since it's not shared
+        assert not _gencode_contains(tmp_path, FnPolicyModuleSharedWeight, rank, r'nnscaler.runtime.function.multiref\(self.pre_input_projection')
 
     for rank in range(2, 4):
         # receive shared weight projection via identity
@@ -483,6 +486,9 @@ def test_codegen_fn_pipeline_shared_weight(tmp_path):
     #         self.init_group(ranks=[0, 1])
     #         self.init_group(ranks=[2, 3])
 
+    #         self.register_parameter('pre_input_projection_weight_58', torch.nn.Parameter(torch.empty((4, 4), dtype=torch.float32)))
+    #         self.add_full_map('pre_input_projection_weight_58', 2, True, 'pre_input_projection.weight', (4, 4), (slice(0, 4, None), slice(0, 4, None)), 1)
+
     #         self.register_parameter('input_projection_weight_55', torch.nn.Parameter(torch.empty((4, 4), dtype=torch.float32)))
     #         self.add_full_map('input_projection_weight_55', 3, True, 'input_projection.weight', (4, 4), (slice(0, 4, None), slice(0, 4, None)), 1)
 
@@ -497,10 +503,14 @@ def test_codegen_fn_pipeline_shared_weight(tmp_path):
     #         self._post_init(init_params, build_buckets)
 
     #     def segment83(self, x_53):
+    #         File "/data/weijiangxu/nnscaler/tests/test_policies.py", line 442, in forward,  x = self.pre_input_projection(x)
+    #         linear_59 = torch.nn.functional.linear(x_56, self.pre_input_projection_weight_58, bias=None)
+    #         del x_56
+
     #         # shared param
     #         input_projection_weight_173, input_projection_weight_174 = nnscaler.runtime.function.multiref(self.input_projection_weight_55, times=2)
     #         # File "/home/weijiangxu/MagicCube/tests/test_policies.py", line 441, in forward,  x = self.input_projection(x)
-    #         linear_56 = torch.nn.functional.linear(x_53, input_projection_weight_173, bias=None)
+    #         linear_56 = torch.nn.functional.linear(linear_59, input_projection_weight_173, bias=None)
     #         del x_53, input_projection_weight_173
     #         linear_56 = nnscaler.runtime.adapter.nn.identity_allreduce(linear_56, ranks=[0, 1])
 


### PR DESCRIPTION
Remove unnecessary multiref addition when pipeline parallelism is enabled. This change also clarifies the conditions under which multiref is applied.