### PR TITLE
[Feat] Add no-grad-reduce annotation

### DIFF
--- a/docs/source/register_custom_op.md
+++ b/docs/source/register_custom_op.md
@@ -46,9 +46,11 @@ def register_op(
     annotation: Union[str, Callable],
     name: Optional[str] = None,
     code_impl_pattern: str = 'import',
+    *,
     emit_fn: Callable[[IRFwOperation, List[str], Dict[str, str], int, int, int], str] = None,
     transform_rules: Tuple[TransformRule] = None,
-    input_gen_fn: Callable[IRFwOperation, List[torch.Tensor]] = None) -> Callable:
+    input_gen_fn: Callable[[IRFwOperation], List[torch.Tensor]] = None,
+    fake_fn: Optional[Callable] = None,
 ) -> Callable:
     ...
 ```
@@ -119,13 +121,67 @@ This function has the following parameters:
     of the operator. By using `input_gen_fn`, we can provide compatible input tensors to the profiler so that the solver can generate a
     good distributed plan.
     Default: None.
+- `fake_fn` (`Callable | None`): a lightweight substitute function used during tracing instead of the real runtime function.
+    It must have the same signature (inputs and outputs, and `requires_grad` flags of all outputs) as the runtime function so that the two are interchangeable.
+    If `fake_fn` is `None`, the runtime function is called directly during tracing.
+    This is useful when the runtime function contains operations that cannot run during tracing
+    (e.g., distributed communication ops, or functions that raise errors outside their intended environment).
+    **Note:** `fake_fn` is not supported for `torch.autograd.Function`. If you need a fake function for an autograd op,
+    wrap it in a plain function and register the wrapper instead.
+    Default: None.
+
+## Fake Function (`fake_fn`)
+
+When registering a custom operator, nnscaler needs to **trace** (execute) the function once to understand its computation graph. However, some functions cannot run during tracing:
+
+- Functions that use distributed communication (e.g., `torch.distributed.all_reduce`)
+- Functions that intentionally raise errors outside their `torchrun` runtime environment
+
+In these cases, you can provide a `fake_fn` — a lightweight stand-in that produces the correct output **shapes, types and `requires_grad` flags** without performing the real computation.
+
+### Requirements
+
+1. `fake_fn` must have the **same input signature** as the runtime function
+2. `fake_fn` must return outputs with the **same shapes and types** as the runtime function
+3. `fake_fn` must set the **same `requires_grad` flags** on its outputs as the runtime function
+4. `fake_fn` should be **simple and fast** — it only runs during tracing, not during training
+5. `fake_fn` is **not supported** for `torch.autograd.Function`
+
+
+### Example: Distributed Communication Op
+
+```python
+import torch
+import torch.distributed as dist
+import nnscaler
+
+def fake_allreduce_linear(x: torch.Tensor, weight: torch.Tensor):
+    # Just compute the linear part — skip the all-reduce
+    return x @ weight.T
+
+@nnscaler.register_op('a b, c b -> a c', fake_fn=fake_allreduce_linear)
+def allreduce_linear(x: torch.Tensor, weight: torch.Tensor):
+    out = x @ weight.T
+    dist.all_reduce(out)  # Cannot run during tracing
+    return out
+```
+
+### When You Don't Need `fake_fn`
+
+If your function can run normally during tracing (e.g., it only uses standard PyTorch ops), you don't need `fake_fn` — just omit it:
+
+```python
+@nnscaler.register_op('a b, b c -> a c')
+def my_matmul(x: torch.Tensor, w: torch.Tensor):
+    return torch.matmul(x, w)
+```
 
 ## `torch.autograd.Function`
 
 If you are using `torch.autograd.Function`, you should register it(internally its `apply` function is registered).
 Otherwise it will be replicated by default, which may lead to poor performance.
 
-```
+```python
 import torch
 import nnscaler
 
@@ -148,6 +204,25 @@ nnscaler.register_op(annotation)(MyFunction)
 or
 ```
 nnscaler.register_op(annotation)(MyFunction.apply)
+```
+
+**Note:** `fake_fn` is not supported for `torch.autograd.Function`. If you need a fake function for an autograd op, wrap it in a plain function and register the wrapper:
+
+```python
+class MyAutograd(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        ...  # real implementation
+    @staticmethod
+    def backward(ctx, grad):
+        ...
+
+def fake_my_op(x: torch.Tensor):
+    return x  # lightweight substitute
+
+@nnscaler.register_op('* -> *', fake_fn=fake_my_op)
+def my_op(x: torch.Tensor):
+    return MyAutograd.apply(x)
 ```
 
 ## `torch.compile` functions
@@ -398,10 +473,10 @@ Without these annotations, nnscaler would insert unnecessary `identity_allreduce
 
 | Partition Type | Input Role | Gradient Behavior |
 |---|---|---|
-| Spatial (`''`) | Partitioned input | No all-reduce needed (gradient is local) |
-| Spatial (`''`) | Replicated input | **All-reduce** by default |
-| Value (`'+'`) | Partitioned input | No all-reduce needed |
-| Value (`'+'`) | Replicated input | **All-reduce** by default |
+| Spatial | Partitioned input | No all-reduce needed (gradient is local) |
+| Spatial | Replicated input | **All-reduce** by default |
+| Value | Partitioned input | No all-reduce needed |
+| Value | Replicated input | **All-reduce** by default |
 | Any | Marked with `: /id` | Skip all-reduce when splitting on `id` |
 | Any | Marked with `: /` | Skip all-reduce for any partition |
 | `'?'` | Replicated only | Normal all-reduce if needed |

--- a/docs/source/register_custom_op.md
+++ b/docs/source/register_custom_op.md
@@ -185,6 +185,7 @@ An `identifier` must be one of:
 Special identifier:
   1) '*': this special identifier indicates the dimension is dynamic, which will automatically get expanded given the shape
   2) '?': this special identifier indicates the value is can only be replicated, no matter it is a tensor or a non-tensor.
+  3) '/': this special identifier indicates the value can only be replicated, and its gradient should be replicated instead of reduced, no matter it is a tensor or a non-tensor. It is a shortcut of '?:/'. See [Gradient Behavior](#gradient-behavior-during-partitioning) for details.
 
 A `reduction` can be a set of {'', '+', '^'}:
   '' indicates this dimension can be partitioned, and each output should have this dimension.
@@ -223,9 +224,11 @@ So we can mark `x` partitioned.
 
 ### Shape Annotation
 
-  e.g., 'a (c+ d^) e'
+  e.g., `'a (c+ d^) e'`
 
 A shape annotation consists of dimension annotation separated by (multiple) spaces.
+
+A shape annotation may also include tensor-level gradient control after a `:` separator. See [Gradient Behavior](#gradient-behavior-during-partitioning) for details.
 
 
 ### Operator Annotation
@@ -323,3 +326,83 @@ def optional_op(x: torch.Tensor, y: Optional[torch.Tensor]) -> torch.Tensor:
 ```
 
 Please note the value of the optional tensor should be consistent in runtime and tracing time. Which mean if the value of the optional tensor is `None` in tracing time, it should always be `None` in runtime, and if the value of optional tensor is not `None` in tracing time, it should always not be `None` in runtime. It may cause runtime error if the consistency is not guaranteed.
+
+
+## Gradient Behavior During Partitioning
+
+When nnscaler partitions an operator across multiple devices, the backward pass may require additional communication to produce correct gradients. Understanding when and why this happens is important for writing correct annotations.
+
+### Default Behavior: Gradient All-Reduce
+
+Consider a matrix multiplication `X = M @ N`, where `M` has shape `(a, b)` and `N` has shape `(b, c)`. The annotation is `'a b+, b+ c -> a c'`.
+
+**Spatial Partition** (splitting on `a`):
+Splitting on `a`:
+- `M` is split along dim 0 into `M1, M2`
+- `N` is replicated
+- Forward: `X1 = M1 @ N`, `X2 = M2 @ N`
+- Backward: given grad `Y1` for `X1`, grad for `N` is `M1^T @ Y1`. But this is only a **partial** gradient — the other device computes `M2^T @ Y2`. The full gradient for `N` requires an **all-reduce** (sum) across devices.
+
+This is the default: when an input is replicated but the operator is partitioned, nnscaler automatically inserts an all-reduce for that input's gradient.
+
+**Value Partition** (splitting on `b`):
+
+Splitting on `b`:
+- `M` is split along dim 1: `M1, M2`
+- `N` is split along dim 0: `N1, N2`
+- Forward: `X = M1 @ N1 + M2 @ N2` (results are summed via all-reduce)
+- Backward: given grad `Y` for `X`:
+  - grad for `M1` = `Y @ N1^T` (correct, no communication needed)
+  - grad for `N1` = `M1^T @ Y` (correct, no communication needed)
+
+  Each device already has the full `Y`, so each device can independently compute the correct gradient for its local partition. **No gradient all-reduce is needed.**
+
+### Skipping Gradient All-Reduce: `: /identifier`
+
+Sometimes the default all-reduce is unnecessary or even harmful. Common cases:
+
+1. **The operator handles gradient reduction internally** (e.g., a custom `torch.autograd.Function` that does its own all-reduce in backward).
+2. **The operator's math makes the all-reduce redundant** (e.g., value partition as shown above, or customized expert parallelism operators where gradients are already correct per-device).
+
+In these cases, you can annotate inputs to skip gradient all-reduce using the `: /identifier` syntax after the dimension annotations:
+
+```
+'<dim_annotations> : /<identifier1> /<identifier2> ...'
+```
+
+**Syntax variants:**
+
+| Annotation | Meaning |
+|---|---|
+| `'a b : /a'` | Skip grad all-reduce for this input when partitioning on `a` |
+| `'a b : /a /b'` | Skip grad all-reduce when partitioning on `a` or `b` |
+| `'a b : /'` | Skip grad all-reduce when partitioning on any identifier (wildcard) |
+| `'/'` | Shortcut for `'?:/'` — input is replicated and never grad-reduced |
+
+**Example: Rotary Position Embedding**
+
+The function `apply_rotary_pos_emb(q, k, cos, sin, position_ids)` takes query `q` of shape `(b, h, s, d)` and key `k` of shape `(b, m, s, d)`. When we split on `m`, `q` is replicated — normally this would trigger a gradient all-reduce on `q`. But because the rotary embedding only rotates each head independently, the partial gradient for `q` from one partition is already the full correct gradient. So we annotate:
+
+```python
+@nnscaler.register_op('b h s^ d^ : /m, b m s^ d^ : /h, s^ d^, s^ d^, s^ -> b h s^ d^, b m s^ d^')
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids):
+    ...
+```
+
+- `'b h s^ d^ : /m'` — when splitting on `m`, don't all-reduce `q`'s gradient
+- `'b m s^ d^ : /h'` — when splitting on `h`, don't all-reduce `k`'s gradient
+
+Without these annotations, nnscaler would insert unnecessary `identity_allreduce` adapters in the generated code, leading to wrong results.
+
+### Summary Table
+
+| Partition Type | Input Role | Gradient Behavior |
+|---|---|---|
+| Spatial (`''`) | Partitioned input | No all-reduce needed (gradient is local) |
+| Spatial (`''`) | Replicated input | **All-reduce** by default |
+| Value (`'+'`) | Partitioned input | No all-reduce needed |
+| Value (`'+'`) | Replicated input | **All-reduce** by default |
+| Any | Marked with `: /id` | Skip all-reduce when splitting on `id` |
+| Any | Marked with `: /` | Skip all-reduce for any partition |
+| `'?'` | Replicated only | Normal all-reduce if needed |
+| `'/'` | Replicated only | **No** all-reduce (shortcut for `'?:/'`) |

--- a/docs/source/register_custom_op.md
+++ b/docs/source/register_custom_op.md
@@ -374,8 +374,8 @@ In these cases, you can annotate inputs to skip gradient all-reduce using the `:
 
 | Annotation | Meaning |
 |---|---|
-| `'a b : /a'` | Skip grad all-reduce for this input when partitioning on `a` |
-| `'a b : /a /b'` | Skip grad all-reduce when partitioning on `a` or `b` |
+| `'a b : /x'` | Skip grad all-reduce for this input when partitioning on `x` |
+| `'a b : /x /y'` | Skip grad all-reduce when partitioning on `x` or `y` |
 | `'a b : /'` | Skip grad all-reduce when partitioning on any identifier (wildcard) |
 | `'/'` | Shortcut for `'?:/'` — input is replicated and never grad-reduced |
 

--- a/docs/source/register_custom_op.md
+++ b/docs/source/register_custom_op.md
@@ -185,7 +185,7 @@ An `identifier` must be one of:
 Special identifier:
   1) '*': this special identifier indicates the dimension is dynamic, which will automatically get expanded given the shape
   2) '?': this special identifier indicates the value is can only be replicated, no matter it is a tensor or a non-tensor.
-  3) '/': this special identifier indicates the value can only be replicated, and its gradient should be replicated instead of reduced, no matter it is a tensor or a non-tensor. It is a shortcut of '?:/'. See [Gradient Behavior](#gradient-behavior-during-partitioning) for details.
+  3) '/': this special identifier is only used as a whole-shape shortcut of '?:/' and in gradient behavior modifiers such as ':/identifier'. It indicates the value can only be replicated, and its gradient should be replicated instead of reduced, no matter it is a tensor or a non-tensor. See [Gradient Behavior](#gradient-behavior-during-partitioning) for details. It should not be used as a regular dimension identifier inside multi-dimension annotations.
 
 A `reduction` can be a set of {'', '+', '^'}:
   '' indicates this dimension can be partitioned, and each output should have this dimension.

--- a/nnscaler/algorithm/ops/dimops.py
+++ b/nnscaler/algorithm/ops/dimops.py
@@ -170,7 +170,7 @@ class DimSplitEinops(GenericDistAlgo):
             inputs = [t[nid] for t in ins]
             outputs = [t[nid] for t in ous]
             kwargs = rule.modifier()(node.kwargs, idx, dim, num, nid)
-            sub_node: IRDimops = node.new(inputs, outputs, **kwargs)
+            sub_node: IRDimops = node.new(inputs, outputs, no_grad_reduce_inputs=rule.no_grad_reduce_inputs, **kwargs)
             sub_node.verify_shape()
             sub_nodes.append(sub_node)
 
@@ -249,7 +249,16 @@ class DimSplitEinops(GenericDistAlgo):
                 updated_kwargs[adim] = updated_kwargs[adim] // num
             return updated_kwargs
 
-        return TransformRule(itransform, otransform, modify)
+        # collect inputs whose grad should not be reduced when splitting on adim
+        no_grad_reduce_inputs = []
+        for input_idx, ianno in enumerate(node.anno.inputs()):
+            if ianno.no_grad_reduce_for(adim):
+                no_grad_reduce_inputs.append(input_idx)
+
+        return TransformRule(
+            itransform, otransform, modify,
+            no_grad_reduce_inputs=no_grad_reduce_inputs,
+        )
 
 
 def collect_split_info(node: IRDimops):

--- a/nnscaler/cli/mixed_module.py
+++ b/nnscaler/cli/mixed_module.py
@@ -129,6 +129,16 @@ class ModuleParallelizeConfigAdapter(PrecisionMixin, PolicyMixin):
             else self.trainer_args.tracing_from_weights
         )
 
+    @property
+    def autoset_requires_grad(self):
+        # for end2end_mode, set it to True (requires_grad of all inputs will be set to False in this case)
+        # for non-end2end_mode, set it to self.parallel_module.forward_args_autoset_requires_grad
+        # if self.parallel_module.forward_args_autoset_requires_grad is False,
+        #   it means the user wants to retain the requires_grad of the dummy input
+        # if self.parallel_module.forward_args_autoset_requires_grad is True,
+        #   it means all float input tensors will be set requires_grad to True
+        return not self.parallel_module or self.parallel_module.forward_args_autoset_requires_grad
+
     def load_tracing_weights(self) -> Optional[dict[str, Any]]:
         tracing_weights = None
         if not self.parallel_module:
@@ -202,6 +212,7 @@ class ModuleParallelizeConfigAdapter(PrecisionMixin, PolicyMixin):
             'gbs': self.trainer_args.global_batch_size,
             'precision': self.trainer_args.precision,
             'model_args': self.trainer_args.model.args,
+            'autoset_requires_grad': self.autoset_requires_grad
         }
         return compute_config
 
@@ -222,6 +233,7 @@ class ModuleParallelizeConfigAdapter(PrecisionMixin, PolicyMixin):
             instance_name=self.instance_name,
             broadcast_strategy=self.broadcast_strategy,
             load_module=load_module,
+            autoset_requires_grad=self.autoset_requires_grad,
         )
         if load_module:
             return pmodel_class(build_buckets=build_buckets)

--- a/nnscaler/cli/trainer_args.py
+++ b/nnscaler/cli/trainer_args.py
@@ -238,6 +238,11 @@ class ModuleParallelizeConfig:
     # for example, mark some dims of tensors as dynamic
     # (you can do it in `forward_args_gen_fn` as well)
     forward_args_post_process_fn: Optional[Callable[['TrainerArgs', dict[str, Any]], dict[str, Any]]] = fn_field(default=None)
+    # whether to automatically set the requires_grad attribute of the dummy sample.
+    # If False, we will retain the requires_grad attribute of the dummy sample.
+    # If True, we will automatically set requires_grad to True for all input tensors in the dummy sample,
+    #   (except when the dtype is not float).
+    forward_args_autoset_requires_grad: bool = True
     # the model state dict file for tracing.
     # It is only used in tracing to serve as the initial state dict of the model.
     tracing_from_weights: str = None

--- a/nnscaler/graph/function/dimops.py
+++ b/nnscaler/graph/function/dimops.py
@@ -149,6 +149,8 @@ class DimAnno:
             anno = (anno,)
         if len(anno) > 1 and any(i in anno for i in _kSpecialIdentifiers):
             raise ValueError(f"Dim annotation cannot have {_kSpecialIdentifiers} as partial dimension.")
+        if any(i == '/' for i in anno):
+            raise ValueError(f"Dim annotation cannot have '/' because it is a special identifier for shape-level control, got {anno}")
         identifiers, reduces = [], []
         for identifier in anno:
             # get reduce type
@@ -351,7 +353,12 @@ class ShapeAnno:
             if token == '/':
                 no_grad_reduce_ids.append('')
             elif token.startswith('/'):
-                no_grad_reduce_ids.append(token[1:])
+                identifier = token[1:]
+                if not identifier.isidentifier():
+                    raise ValueError(
+                        f"Syntax Error: expected valid identifier after '/', got '{identifier}'"
+                    )
+                no_grad_reduce_ids.append(identifier)
             else:
                 raise ValueError(
                     f"Syntax Error: expected /identifier or / after ':' in shape annotation, got '{token}'"

--- a/nnscaler/graph/function/dimops.py
+++ b/nnscaler/graph/function/dimops.py
@@ -22,6 +22,8 @@ An `identifier` must be one of:
 Special identifier:
   1) '*': this special identifier indicates the dimension is dynamic, which will automatically get expanded given the shape
   2) '?': this special identifier indicates the value is can only be replicated, no matter it is a tensor or a non-tensor.
+  3) '/': this special identifier indicates the value can only be replicated, and its gradient should be replicated instead of reduced, no matter it is a tensor or a non-tensor.
+          It is a shortcut of '?:/'
 
 A `reduction` can be a set of {'', '+', '^'}:
   '' indicates this dimension can be partitioned, and each output should have this dimension.
@@ -36,6 +38,15 @@ The value of inner dimension needs to be inferrable, or indicated by function ar
   e.g., 'a (c+ d^) e'
 
 A shape annotation consists of dimension annotation separated by (multiple) spaces.
+
+A shape annotation may also include tensor-level control after a ':' separator.
+Currently we only support '/' or '/identifier',
+which indicates that when partitioning on that identifier,
+the gradient for this input should not be all-reduced (By default, gradients are all-reduced when partitioning).
+Multiple modifiers are allowed.
+  e.g., 'l h^ : /m' means when splitting on 'm', skip grad reduce for this input.
+  e.g., 'l h^ : /m /n' means skip grad reduce when splitting on 'm' or 'n'.
+  e.g., 'l h^ : /' means skip grad reduce when splitting on any identifier.
 
 
 * Operator Annotation:
@@ -76,7 +87,7 @@ from nnscaler.ir.cten import IRTensor, IRObject, ValueTrack
 from nnscaler.ir.operator import IRFwOperation
 
 
-_kSpecialIdentifiers = ('*', '?')
+_kSpecialIdentifiers = ('*', '?', '/')
 _logger = logging.getLogger(__name__)
 
 
@@ -164,14 +175,37 @@ class ShapeAnno:
     Shape annotation
 
     e.g., a (b+ dim)  d^
+
+    Supports /identifier modifiers after a ':' separator to indicate that when
+    partitioning on the given identifier, this input's gradient should not be all-reduced.
+    e.g., 'l h^ : /m' means when splitting on 'm', skip grad reduce for this input.
+    Multiple modifiers are allowed: 'l h^ : /m /n'
     """
 
-    def __init__(self, dim_annos: Union[str, Tuple[DimAnno]]):
+    def __init__(
+        self,
+        dim_annos: Union[str, Tuple[DimAnno]],
+        *,
+        no_grad_reduce_ids: Optional[Tuple[str, ...]] = None
+    ):
         assert isinstance(dim_annos, str) or all(isinstance(adim, DimAnno) for adim in dim_annos), \
             f"dim_annos must be str or Tuple[DimAnno] but got {dim_annos}"
         if isinstance(dim_annos, str):
-            dim_annos = ShapeAnno.parse(dim_annos)
+            if no_grad_reduce_ids is not None:
+                raise ValueError("Cannot specify no_grad_reduce_ids when dim_annos is str, please include them in the annotation string after ':'")
+
+            dim_annos = dim_annos.strip()
+            if dim_annos == '/':  # shortcut for "?:/"
+                dim_annos = '?:/'
+            if ':' in dim_annos:
+                dim_annos, meta_annos = dim_annos.split(':', 1)
+            else:
+                dim_annos, meta_annos = dim_annos, ''
+            dim_annos = self._parse_dims(dim_annos)
+            no_grad_reduce_ids = self._parse_meta(meta_annos)
+
         self._dims: Tuple[DimAnno] = dim_annos
+        self._no_grad_reduce_ids: Tuple[str, ...] = tuple(no_grad_reduce_ids) if no_grad_reduce_ids else ()
 
     @property
     def dims(self) -> Tuple[DimAnno, ...]:
@@ -211,7 +245,29 @@ class ShapeAnno:
         self._dims[index] = dim_anno
 
     def __repr__(self) -> str:
-        return ' '.join(repr(dim) for dim in self._dims)
+        parts = [repr(dim) for dim in self._dims]
+        base = ' '.join(parts)
+        if self._no_grad_reduce_ids:
+            modifiers = ' '.join(f'/{id}' for id in self._no_grad_reduce_ids)
+            return f'{base} : {modifiers}'
+        return base
+
+    def no_grad_reduce_for(self, identifier: str) -> bool:
+        """Check if grad reduce should be skipped when partitioning on the given identifier.
+
+        Returns True if:
+        - '/' (wildcard, stored as '') is in no_grad_reduce_ids, or
+        - the specific identifier is in no_grad_reduce_ids
+        """
+        return '' in self._no_grad_reduce_ids or identifier in self._no_grad_reduce_ids
+
+    @property
+    def no_grad_reduce_ids(self) -> Tuple[str, ...]:
+        """
+        Identifiers for which this input's gradient should not be reduced.
+        '' (empty string) is a wildcard that indicates all identifiers.
+        """
+        return self._no_grad_reduce_ids
 
     @property
     def ignore(self) -> bool:
@@ -222,8 +278,20 @@ class ShapeAnno:
         """
         return self.ndims == 1 and self._dims[0].name == '?'
 
+    @property
+    def no_grad_reduce(self) -> bool:
+        """!
+        Check if the shape should skip grad reduce when partitioning on any identifier.
+
+        Return:
+            bool: True if the shape should skip grad reduce
+                    when partitioning on any identifier,
+                  else False
+        """
+        return '' in self._no_grad_reduce_ids
+
     @staticmethod
-    def parse(shape_anno: str) -> Tuple[DimAnno]:
+    def _parse_dims(shape_anno: str) -> Tuple[DimAnno]:
         """
         Parse annotations like of a single shape, e.g.,
             a (b+ dim)  d^
@@ -271,6 +339,24 @@ class ShapeAnno:
             edims.append(current_identifier)
         dim_annos = tuple(DimAnno(edim) for edim in edims)
         return dim_annos
+
+    @staticmethod
+    def _parse_meta(meta_anno: str) -> List[str]:
+        """Extract /identifier modifiers from shape annotation string.
+        e.g., '/m /n' -> ['m', 'n']
+        e.g., '/' -> ['']  (empty string means all identifiers)
+        """
+        no_grad_reduce_ids = []
+        for token in meta_anno.strip().split():
+            if token == '/':
+                no_grad_reduce_ids.append('')
+            elif token.startswith('/'):
+                no_grad_reduce_ids.append(token[1:])
+            else:
+                raise ValueError(
+                    f"Syntax Error: expected /identifier or / after ':' in shape annotation, got '{token}'"
+                )
+        return no_grad_reduce_ids
 
     @staticmethod
     def create_shape_str(shape: Tuple[int], reduction: str = '', iterator: Optional[Iterable] = None) -> List[str]:
@@ -656,11 +742,14 @@ class TransformRule:
         irules: Tuple[DimopSplit],
         orules: Tuple[DimopSplit],
         kwarg_modifier: Optional[Callable[[Dict, int, Union[int, str], int, int], Dict]] = None,
+        *,
+        no_grad_reduce_inputs: Optional[List[int]] = None,
     ) -> None:
         self._inputs = tuple(irules)
         self._outputs = tuple(orules)
         modifier = kwarg_modifier if kwarg_modifier is not None else TransformRule.default_modifier
         self._modifier = (modifier,)
+        self._no_grad_reduce_inputs = no_grad_reduce_inputs or []
 
     def inputs(self) -> Tuple[DimopSplit]:
         return self._inputs
@@ -676,6 +765,10 @@ class TransformRule:
 
     def modifier(self) -> Optional[Callable]:
         return self._modifier[0]
+
+    @property
+    def no_grad_reduce_inputs(self) -> List[int]:
+        return self._no_grad_reduce_inputs
 
     def __repr__(self) -> str:
         inputs = ', '.join(repr(split) for split in self._inputs)
@@ -733,6 +826,13 @@ class IRDimops(IRFwOperation):
                 f"kwargs: {kwargs}\n"
             )
 
+        # no grad reduce config for this operator annotated by '/',
+        # will be set to specific input indices
+        # when creating new operator with `new` function, and used in transform rules to determine whether to skip grad reduce when partitioning on specific identifier.
+        self._no_grad_reduce_inputs = [
+            idx for idx, ianno in enumerate(self._iannos) if ianno.no_grad_reduce
+        ]
+
         n_outputs = len(self._oannos)
         super().__init__(name, signature, inputs, n_outputs, constant_foldable=constant_foldable, **kwargs)
 
@@ -787,7 +887,13 @@ class IRDimops(IRFwOperation):
             shapes[oidx] = tuple(shape)
         return shapes
 
-    def new(self, inputs: List[IRTensor], outputs: List[IRTensor], **kwargs):
+    def new(
+        self,
+        inputs: List[IRTensor], outputs: List[IRTensor],
+        *,
+        no_grad_reduce_inputs: Optional[List[int]] = None,
+        **kwargs
+    ):
         """!
         Construct a new operator sharing same kwargs with new inputs
         and outputs
@@ -798,12 +904,40 @@ class IRDimops(IRFwOperation):
         @return op IRDimop: the new constructed operator
         """
         op = self._create_fn[0](*inputs, **kwargs, signature=self.signature)
+        if no_grad_reduce_inputs is not None:
+            op._no_grad_reduce_inputs = no_grad_reduce_inputs
         # annos = self._annos_candidates
         # rules = self._trans_rules
         # op = IRDimops(self.signature, annos, inputs, self.name, rules, **kwargs)
         for idx, output in enumerate(outputs):
             op.set_output(idx, output)
         return op
+
+    def ignore_grad_reduce(self, *, input_idx: int) -> bool:
+        return self._no_grad_reduce_inputs is not None \
+            and input_idx in self._no_grad_reduce_inputs
+
+    def _resolve_identifier_from_kwargs(
+            self, signature: str, identifier: str, kwargs: Dict
+    ) -> int:
+        if identifier not in kwargs:
+            raise ValueError(
+                f"Function {signature}: identifier {identifier} not found in kwargs, "
+                f"cannot resolve the length of this identifier for shape inference. "
+            )
+
+        if isinstance(kwargs[identifier], IRObject):
+            _logger.warning(
+                f"Function {signature}: Found identifier {identifier} in kwargs to be IRObject, "
+                f"this will turn it into a static value. Pay attention to the usage "
+                f"in dynamic-shape scenarios")
+            kwargs[identifier] = kwargs[identifier].value
+        length = kwargs[identifier]
+        if not isinstance(length, int):
+            raise ValueError(
+                f"Function {signature}: identifier {identifier} in kwargs "
+                f"must be int or IRObject[value=int], but got {length}")
+        return length
 
     def align(self, signature, inputs: List[IRTensor], op_anno: OpAnno, kwargs: Dict) -> bool:
         """!
@@ -837,8 +971,9 @@ class IRDimops(IRFwOperation):
                         expand_dims = []
                         if ndims > 0:
                             expand_dims = list(DimAnno(candicates[dim] + reduce) for dim in range(ndims))
-                    shape_anno = list(op_anno.input(idx).dims[:pos]) + expand_dims + list(op_anno.input(idx).dims[pos+1:])
-                    shape_anno = ShapeAnno(tuple(shape_anno))
+                    orig_input = op_anno.input(idx)
+                    shape_anno = list(orig_input.dims[:pos]) + expand_dims + list(orig_input.dims[pos+1:])
+                    shape_anno = ShapeAnno(tuple(shape_anno), no_grad_reduce_ids=orig_input.no_grad_reduce_ids)
                     op_anno.set_input(idx, shape_anno)
             # * should appear in inputs
             assert expand_dims is not None, f"Syntax Error: {op_anno}: * should also appear in inputs"
@@ -847,8 +982,9 @@ class IRDimops(IRFwOperation):
                 names = [dim_anno.name for dim_anno in shape_anno.dims]
                 if '*' in names:
                     pos = names.index('*')
-                    shape_anno = list(op_anno.output(idx).dims[:pos]) + expand_dims + list(op_anno.output(idx).dims[pos+1:])
-                    shape_anno = ShapeAnno(tuple(shape_anno))
+                    orig_output = op_anno.output(idx)
+                    shape_anno = list(orig_output.dims[:pos]) + expand_dims + list(orig_output.dims[pos+1:])
+                    shape_anno = ShapeAnno(tuple(shape_anno), no_grad_reduce_ids=orig_output.no_grad_reduce_ids)
                     op_anno.set_output(idx, shape_anno)
             op_anno.reset_identifiers()
 
@@ -890,17 +1026,7 @@ class IRDimops(IRFwOperation):
                         length = op_anno.getlen(identifier)
                         if length is None:
                             if identifier in kwargs:
-                                if isinstance(kwargs[identifier], IRObject):
-                                    _logger.warning(
-                                        f"Function {signature}: Found identifier {identifier} in kwargs to be IRObject, "
-                                        f"this will turn it into a static value. Pay attention to the usage "
-                                        f"in dynamic-shape scenarios")
-                                    kwargs[identifier] = kwargs[identifier].value
-                                length = kwargs[identifier]
-                                if not isinstance(length, int):
-                                    raise ValueError(
-                                        f"Function {signature}: identifier {identifier} in kwargs "
-                                        f"must be int or IRObject[value=int], but got {length}")
+                                length = self._resolve_identifier_from_kwargs(signature, identifier, kwargs)
                                 ret = op_anno.setlen(identifier, length)
                                 accum *= length
                             elif identifier in identifier_values:
@@ -918,6 +1044,17 @@ class IRDimops(IRFwOperation):
                         ret = op_anno.setlen(toinfer[0], dimlen // accum)
                 if not ret:
                     return False
+
+        # resolve output-only identifiers from kwargs
+        for oshape in op_anno.outputs():
+            if oshape.ignore:
+                continue
+            for odim in oshape.dims:
+                for identifier in odim.identifiers:
+                    if op_anno.getlen(identifier) is None and identifier in kwargs:
+                        length = self._resolve_identifier_from_kwargs(signature, identifier, kwargs)
+                        op_anno.setlen(identifier, length)
+
         return True
 
     def transform_space(self) -> List[Tuple[int, int]]:

--- a/nnscaler/graph/graph.py
+++ b/nnscaler/graph/graph.py
@@ -415,17 +415,24 @@ class IRGraph(IRSegment):
                 consumers.setdefault(itensor.parent, []).append(fnode)
         # set up gradient
         for fnode in fnodes:
-            for itensor in fnode.inputs():
+            for input_idx, itensor in enumerate(fnode.inputs()):
                 if not isinstance(itensor, IRSubTensor): continue
                 ftensor = itensor.parent
                 itensor.grad = None
                 if valmaps[ftensor] is None: continue
-                # collect consumers that consume the same sub_tensor
-                consumers_of_same_tensor = []
-                for idx, t in enumerate(ctensors[ftensor]):
-                    if t == itensor:
-                        consumers_of_same_tensor.append(consumers[ftensor][idx])
-                consumers_of_same_tensor = consumers_of_same_tensor[::-1]  # make valmap grow with exec order
+                if isinstance(fnode, IRDimops) and fnode.ignore_grad_reduce(input_idx=input_idx):
+                    # ignore possible gradient reduction on this input
+                    # this is mainly for customized gradient reduction.
+                    # for example, if the reduction will be done inside the operator
+                    # we don't need to generate extra adapter for gradient reduction.
+                    consumers_of_same_tensor = [fnode]
+                else:
+                    # collect consumers that consume the same sub_tensor
+                    consumers_of_same_tensor = []
+                    for idx, t in enumerate(ctensors[ftensor]):
+                        if t == itensor:
+                            consumers_of_same_tensor.append(consumers[ftensor][idx])
+                    consumers_of_same_tensor = consumers_of_same_tensor[::-1]  # make valmap grow with exec order
                 # calculate value map
                 valmap = valmaps[ftensor].map(
                     (consumers_of_same_tensor.index(fnode), len(consumers_of_same_tensor))

--- a/nnscaler/parallel.py
+++ b/nnscaler/parallel.py
@@ -712,6 +712,7 @@ def _gen_graph(
     constant_folding: bool,
     end2end_mode: bool = False,
     inference_only: bool = False,
+    autoset_requires_grad: bool = True,
 ):
     # reset environment
     IDGenerator().clear()
@@ -729,7 +730,7 @@ def _gen_graph(
         # in end2end mode, we don't need gradients for inputs
         # in normal mode, we assume all inputs require gradients
         # so it can connect to other parts of the graph correctly
-        requires_grad=not end2end_mode
+        requires_grad=not end2end_mode if autoset_requires_grad else None
     )
     fx_graph = parser.to_fx_graph(module, dummy_forward_args)
 
@@ -780,6 +781,7 @@ def _gencode(
         *,
         module_dtype:  Optional[torch.dtype] = None,
         module_fn: Optional[Callable[[], torch.nn.Module]] = None,
+        autoset_requires_grad: bool = True,
     ) -> RegenStatus:
     """
     Generate parallel module source code from a torch module, and save it to file.
@@ -799,7 +801,7 @@ def _gencode(
         outdir (Path): the directory to save generated code
         module_dtype (Optional[torch.dtype]): the dtype of the module. Keep as it is when it is None.
         module_fn (Optional[Callable[[], torch.nn.Module]]): the function to create the module. Will use __init__ if it is None.
-
+        autoset_requires_grad (bool): whether to automatically set the requires_grad of input tensors.
     Returns:
         RegenStatus: which part is regenerated.
     """
@@ -845,6 +847,7 @@ def _gencode(
                 wrapped_module, dummy_forward_args, outdir,
                 constant_folding=compute_config.constant_folding, end2end_mode=compute_config.use_end2end,
                 inference_only=compute_config.inference_only,
+                autoset_requires_grad=autoset_requires_grad,
             )
 
         graph.dump(graph_ckp)
@@ -985,6 +988,7 @@ def parallelize(
     init_module_params: bool = True,
     build_module_buckets: bool = True,
     broadcast_strategy: Union[str, BroadcastGenFilesStrategy] = 'none',
+    autoset_requires_grad: bool = True,
 ) -> Union[None, ParallelModule, Type[ParallelModule]]:
     """
     Convert a torch.nn.Module object or class to ParallelModule object or class.
@@ -1068,6 +1072,12 @@ def parallelize(
         broadcast_strategy (Union[str, BroadcastGenFilesStrategy]): the broadcast strategy for generated files.
             Please note that the broadcasting will only be done in torchrun environment,
             and will throw an error if torch.distributed is not initialized and broadcast_strategy is not NONE.
+        autoset_requires_grad (bool):
+            whether to automatically set the requires_grad attribute of the dummy forward arguments.
+            If false, we will retain the requires_grad attribute of the dummy forward arguments.
+            If true, we will automatically set requires_grad according to compute_config and tensor dtypes.
+            Note set requires_grad to True for end2end module is not useful,
+            and this argument is mainly for non-end2end module.
     Returns:
         Union[ParallelModule, Type[ParallelModule], None]:
             if load_module flag is set, return the converted ParallelModule object or class
@@ -1125,6 +1135,7 @@ def parallelize(
                         outdir,
                         module_dtype=module_dtype,
                         module_fn=module_fn,
+                        autoset_requires_grad=autoset_requires_grad,
                     )
             else:
                 regen_status = RegenStatus.NONE

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -551,8 +551,8 @@ def fn(
     # key: IRFullTensor
     # value:
     #   key: stage_id
-    #   value: set of OpPartition in this stage
-    tensor_splits: dict[IRFullTensor, dict[int, set[OpPartition]]] = {}
+    #   value: set of dims in this stage, None if the tensor is replicated in this stage
+    tensor_splits: dict[IRFullTensor, dict[int, set[Optional[int]]]] = {}
     # store the last split info for each tensor to help handle auto partition
     # None: replicated
     # 'value': value partitioned
@@ -641,8 +641,9 @@ def fn(
                 # then we can update input/output partition info
 
                 # make sure the first item in op_partition_map is the first partition plan
-                op_partition_map[op_first_partition.input] = op_first_partition.dim
-                op_partition_map.update(result_partitions)
+                if result_partitions:
+                    op_partition_map[op_first_partition.input] = op_first_partition.dim
+                    op_partition_map.update(result_partitions)
 
                 for output in subnode.outputs():
                     if not isinstance(output, IRSubTensor):
@@ -678,8 +679,7 @@ def fn(
             if idx not in op_partition_map:
                 tensor_splits[ftensor].setdefault(op_plan.stage_id, set()).add(None)
             else:
-                tensor_splits[ftensor].setdefault(op_plan.stage_id, set()).add(
-                    OpPartition(input=idx, dim=op_partition_map[idx]))
+                tensor_splits[ftensor].setdefault(op_plan.stage_id, set()).add(op_partition_map[idx])
 
         if op_plan.recompute_id != -1:
             if op_plan.recompute_id in recompute_group_stages:
@@ -748,7 +748,7 @@ def fn(
     for ftensor, stage_info in tensor_splits.items():
         if not ftensor.is_param():
             continue
-        splits = set(k.dim if k is not None else None for v in stage_info.values() for k in v)
+        splits = set(k for v in stage_info.values() for k in v)
         find_replicated = None in splits
         splits = list(splits)
         # For safety, we will add multiref when detecting shared param are all replicated for pipeline parallelism.

--- a/tests/cli/test_autoset_requires_grad.py
+++ b/tests/cli/test_autoset_requires_grad.py
@@ -1,0 +1,54 @@
+#  Copyright (c) Microsoft Corporation.
+#  Licensed under the MIT License.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nnscaler.cli.trainer import Trainer
+from tests.utils import replace_all_device_with
+
+
+@replace_all_device_with('cpu')
+def test_end2end(tmp_path):
+    save_dir = Path(tmp_path)
+    config_path = str(Path(__file__).with_name('trainer_args.yaml').resolve())
+    gen_savedir = save_dir / 'gen'
+    # compile only
+    trainer = Trainer([
+        '-f', config_path,
+        '--max_epochs', '2',
+        '--gen_savedir', str(gen_savedir),
+        '--compute_config.plan_ngpus', '2',
+        '--compute_config.runtime_ngpus', '4',
+        '--checkpoint.no_save', 'true',
+        '--run_mode', 'compile',
+        '--broadcast_strategy', 'none',
+    ])
+    with patch('nnscaler.cli.mixed_module.nnscaler.parallelize') as mocked_parallelize:
+        trainer.run()
+        assert mocked_parallelize.call_args.kwargs['autoset_requires_grad'] is True
+
+
+@replace_all_device_with('cpu')
+@pytest.mark.parametrize('autoset_requires_grad', [True, False])
+def test_not_end2end(tmp_path, autoset_requires_grad):
+    save_dir = Path(tmp_path)
+    config_path = str(Path(__file__).with_name('trainer_args_mixed1.yaml').resolve())
+    gen_savedir = save_dir / 'gen'
+    # compile only
+    trainer = Trainer([
+        '-f', config_path,
+        '--max_epochs', '2',
+        '--gen_savedir', str(gen_savedir),
+        '--compute_config.plan_ngpus', '2',
+        '--compute_config.runtime_ngpus', '4',
+        '--checkpoint.no_save', 'true',
+        '--run_mode', 'compile',
+        '--broadcast_strategy', 'none',
+        '--model.parallel_modules.0.forward_args_autoset_requires_grad', str(autoset_requires_grad).lower(),
+    ])
+    with patch('nnscaler.cli.mixed_module.nnscaler.parallelize') as mocked_parallelize:
+        trainer.run()
+        assert mocked_parallelize.call_args.kwargs['autoset_requires_grad'] is autoset_requires_grad

--- a/tests/graph/function/test_dimops.py
+++ b/tests/graph/function/test_dimops.py
@@ -172,7 +172,7 @@ def test_slash_shortcut():
     assert s.no_grad_reduce_for('x') is True
     # dims should be '?'
     assert s.ndims == 1
-    assert s._dims[0].name == '?'
+    assert s.dims[0].name == '?'
 
 
 def test_question_mark():

--- a/tests/graph/function/test_dimops.py
+++ b/tests/graph/function/test_dimops.py
@@ -11,7 +11,7 @@ from functools import partial
 import pytest
 
 import nnscaler.graph.function as F
-from nnscaler.graph.function.dimops import IRDimops, OpAnno
+from nnscaler.graph.function.dimops import IRDimops, OpAnno, ShapeAnno, DimAnno
 from nnscaler.ir.tensor import IRFullTensor
 from nnscaler.ir.cten import IRObject, IRTensor
 
@@ -125,3 +125,144 @@ def test_parse_op():
 
     with pytest.raises(ValueError):
         str(OpAnno('a b^, b^ c -> a c^')) == 'a b^, b^ c -> a c^'
+
+
+def test_plain_shape_no_meta():
+    """Plain shape without ':' has no no_grad_reduce_ids."""
+    s = ShapeAnno('a b c')
+    assert s.no_grad_reduce_ids == ()
+    assert s.no_grad_reduce is False
+    assert s.no_grad_reduce_for('a') is False
+
+
+def test_single_modifier():
+    """'a b : /m' marks only 'm'."""
+    s = ShapeAnno('a b : /m')
+    assert s.no_grad_reduce_ids == ('m',)
+    assert s.no_grad_reduce is False
+    assert s.no_grad_reduce_for('m') is True
+    assert s.no_grad_reduce_for('a') is False
+
+
+def test_multiple_modifiers():
+    """'a b : /m /n' marks 'm' and 'n'."""
+    s = ShapeAnno('l h^ : /m /n')
+    assert s.no_grad_reduce_ids == ('m', 'n')
+    assert s.no_grad_reduce_for('m') is True
+    assert s.no_grad_reduce_for('n') is True
+    assert s.no_grad_reduce_for('l') is False
+    assert s.no_grad_reduce is False
+
+
+def test_wildcard_modifier():
+    """'a b : /' is a wildcard — all identifiers match."""
+    s = ShapeAnno('l h^ : /')
+    assert s.no_grad_reduce_ids == ('',)
+    assert s.no_grad_reduce is True
+    assert s.no_grad_reduce_for('l') is True
+    assert s.no_grad_reduce_for('h') is True
+    assert s.no_grad_reduce_for('anything') is True
+
+
+def test_slash_shortcut():
+    """'/' alone is shortcut for '?:/' — ignore=True with wildcard no_grad_reduce."""
+    s = ShapeAnno('/')
+    assert s.ignore is True
+    assert s.no_grad_reduce is True
+    assert s.no_grad_reduce_for('x') is True
+    # dims should be '?'
+    assert s.ndims == 1
+    assert s._dims[0].name == '?'
+
+
+def test_question_mark():
+    """'?' is ignore but has no no_grad_reduce."""
+    s = ShapeAnno('?')
+    assert s.ignore is True
+    assert s.no_grad_reduce is False
+    assert s.no_grad_reduce_for('x') is False
+
+
+def test_repr_plain():
+    s = ShapeAnno('a b^ c')
+    assert repr(s) == 'a b^ c'
+
+
+def test_repr_with_modifier():
+    s = ShapeAnno('a b : /m')
+    assert repr(s) == 'a b : /m'
+
+
+def test_repr_with_multiple_modifiers():
+    s = ShapeAnno('l h^ : /m /n')
+    assert repr(s) == 'l h^ : /m /n'
+
+
+def test_repr_wildcard():
+    s = ShapeAnno('l h^ : /')
+    assert repr(s) == 'l h^ : /'
+
+
+def test_repr_slash_shortcut():
+    """'/' becomes '?:/' internally, repr shows '?^ : /'."""
+    s = ShapeAnno('/')
+    assert repr(s) == '?^ : /'
+
+
+def test_construct_from_tuple_with_no_grad_reduce_ids():
+    dims = ShapeAnno._parse_dims('a b c')
+    s = ShapeAnno(dims, no_grad_reduce_ids=('a', 'b'))
+    assert s.no_grad_reduce_ids == ('a', 'b')
+    assert s.no_grad_reduce_for('a') is True
+    assert s.no_grad_reduce_for('c') is False
+
+
+def test_construct_from_tuple_wildcard():
+    dims = ShapeAnno._parse_dims('a b')
+    s = ShapeAnno(dims, no_grad_reduce_ids=('',))
+    assert s.no_grad_reduce is True
+    assert s.no_grad_reduce_for('a') is True
+
+
+def test_str_with_kwarg_raises():
+    """Cannot pass no_grad_reduce_ids when dim_annos is a string."""
+    with pytest.raises(ValueError):
+        ShapeAnno('a b', no_grad_reduce_ids=('m',))
+
+
+def test_invalid_meta_token():
+    with pytest.raises(ValueError, match="expected /identifier"):
+        ShapeAnno('a b : m')
+
+
+def test_invalid_meta_token2():
+    with pytest.raises(ValueError, match="expected /identifier"):
+        ShapeAnno('a b : foo')
+
+
+def test_star_expansion_preserves_no_grad_reduce_ids():
+    """When '*' expansion happens in IRDimops.align(), no_grad_reduce_ids should be preserved."""
+    def StarOp(input, weight, signature='star_op'):
+        anno = '* a : /c, a b -> * b'
+        return IRDimops(StarOp, 'star_op', signature, [anno], [input, weight])
+
+    op = create_op(StarOp, [(4, 8, 16), (16, 32)])
+    # After align, the first input's '*' expands but no_grad_reduce_ids should remain
+    ianno = op.anno.input(0)
+    assert ianno.no_grad_reduce_for('c') is True
+
+
+def test_opanno_with_no_grad_reduce():
+    """OpAnno should preserve no_grad_reduce modifiers in input ShapeAnnos."""
+    anno = OpAnno('a b : /a, b c -> a c')
+    ianno = anno.input(0)
+    assert ianno.no_grad_reduce_for('a') is True
+    assert ianno.no_grad_reduce_for('b') is False
+
+
+def test_opanno_slash_input():
+    """OpAnno with '/' input (the ignore+no_grad_reduce shortcut)."""
+    anno = OpAnno('a b, / -> a b')
+    ianno = anno.input(1)
+    assert ianno.ignore is True
+    assert ianno.no_grad_reduce is True

--- a/tests/graph/parser/test_parser.py
+++ b/tests/graph/parser/test_parser.py
@@ -208,7 +208,7 @@ def test_non_tensor_multiple_outputs(tmp_path, output_list):
     ir_graph = to_ir_graph(fx_graph, dummy_input, attr_savedir=tmp_path, constant_folding=False)
     print(ir_graph.extra_repr())
 
-    # the output number of node depends on the annoation.
+    # the output number of node depends on the annotation.
     # the right part of both func_output_list3 and func_output_list4 are the same ( `?, ?`)
     # so two outputs are expected
     assert len(ir_graph.nodes()[-1].outputs()) == 2
@@ -254,7 +254,7 @@ def test_non_tensor_multiple_outputs2(tmp_path, output_list):
     ir_graph = to_ir_graph(fx_graph, dummy_input, attr_savedir=tmp_path, constant_folding=False)
     print(ir_graph.extra_repr())
 
-    # the output number of node depends on the annoation.
+    # the output number of node depends on the annotation.
     # the right part of both func_output_list3 and func_output_list4 are the same ( `?`)
     # so 1 output are expected
     assert len(ir_graph.nodes()[-1].outputs()) == 1
@@ -290,7 +290,7 @@ def test_non_tensor_multiple_outputs3(tmp_path, output_list):
     ir_graph = to_ir_graph(fx_graph, dummy_input, attr_savedir=tmp_path, constant_folding=False)
     print(ir_graph.extra_repr())
 
-    # the output number of node depends on the annoation.
+    # the output number of node depends on the annotation.
     # the right part of both func_output_list3 and func_output_list4 are the same ( `?`)
     # so 1 output are expected
     assert len(ir_graph.nodes()[-1].outputs()) == 1

--- a/tests/parallel_module/test_autoset_requires_grad.py
+++ b/tests/parallel_module/test_autoset_requires_grad.py
@@ -1,0 +1,57 @@
+#  Copyright (c) Microsoft Corporation.
+#  Licensed under the MIT License.
+
+from pathlib import Path
+import tempfile
+
+import torch
+import pytest
+
+from nnscaler.graph import IRGraph
+from nnscaler.parallel import ComputeConfig, _gen_graph, parallelize
+
+from ..utils import replace_all_device_with
+
+
+class QuickModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(3, 5)
+
+    def forward(self, x):
+        x = self.linear(x)
+        return torch.sum(x)
+
+
+@replace_all_device_with('cpu')
+@pytest.mark.parametrize('autoset_requires_grad', [True, False])
+@pytest.mark.parametrize('end2end_mode', [True, False])
+@pytest.mark.parametrize('requires_grad', [True, False])
+def test_gen_graph_autoset_requires_grad_non_end2end(
+    tmp_path: Path,
+    autoset_requires_grad: bool,
+    end2end_mode: bool,
+    requires_grad: bool
+):
+    parallelize(
+            QuickModule(),
+            {'x': torch.randn(2, 3, requires_grad=requires_grad)},
+            'dp',
+            ComputeConfig(1, 1, use_end2end=end2end_mode),
+            gen_savedir=tmp_path,
+            reuse='override',
+            autoset_requires_grad=autoset_requires_grad,
+            load_module=False,
+    )
+    graph_ckp = list(Path(tmp_path).glob('**/graph.ckp'))[0]
+    graph = IRGraph.load(graph_ckp)
+    if end2end_mode:
+        input_tensor = graph.node(0).output(0)
+    else:
+        input_tensor = graph.input(0)
+
+    assert input_tensor.name == 'x'
+    assert input_tensor.requires_grad == (
+        (autoset_requires_grad and not end2end_mode)
+        or (not autoset_requires_grad and requires_grad)
+    )

--- a/tests/parallel_module/test_gencode_ep.py
+++ b/tests/parallel_module/test_gencode_ep.py
@@ -1,0 +1,1133 @@
+from typing import List, Optional
+
+import torch
+import torch.nn.functional as F
+import torch.nn as nn
+import math
+
+import nnscaler
+from nnscaler.graph.function import DimopSplit, TransformRule
+from nnscaler.graph.schedule.schedplan import SchedulePlan, StreamConfig, StreamContext
+from nnscaler.graph.segment import IRSegment
+from nnscaler.parallel import IRGraph
+from nnscaler.policies import get_pas_ops
+
+from .test_gencode import print_gencode, _gencode_contains, replace_all_device_with
+
+
+@nnscaler.register_op('l m^ -> ?, ?,?, ?')
+def step1_preprocess(routing_map, num_local_experts, num_experts, ep_size):
+    """Gather per-expert token counts across EP ranks and compute split sizes.
+    """
+    # shape: num_tokens_per_local_expert: self.num_local_experts
+    num_local_tokens_per_expert = routing_map.sum(dim=0).long()
+
+    # preprocess
+    input_splits = num_local_tokens_per_expert.reshape(ep_size, num_local_experts).sum(axis=1)
+    num_global_tokens_per_expert = torch.zeros(ep_size, num_experts, dtype=num_local_tokens_per_expert.dtype, device=num_local_tokens_per_expert.device)
+    num_global_tokens_per_local_expert = num_global_tokens_per_expert[:, :num_local_experts].contiguous()
+    output_splits = num_global_tokens_per_local_expert.sum(axis=1)
+    num_tokens_per_local_expert = num_global_tokens_per_local_expert.sum(axis=0)
+
+    if num_local_experts > 1:
+        num_global_tokens_per_local_expert = num_global_tokens_per_local_expert.view(-1, num_local_experts)
+
+    return (
+        num_tokens_per_local_expert,
+        num_global_tokens_per_local_expert,
+        input_splits.tolist(),
+        output_splits.tolist(),
+    )
+
+@nnscaler.register_op('l h^, l m^, l m^ -> /, /, /')
+def step2_permute(hidden_states, routing_map, routing_probs, topk):
+    """Permute tokens so same-expert tokens are contiguous.
+    """
+    return hidden_states.repeat_interleave(topk, dim=0).clone(), \
+        routing_map.int().topk(topk, dim=1)[0].flatten().clone(), \
+        routing_probs.topk(topk, dim=1)[0].flatten().clone()
+
+
+@nnscaler.register_op('/, / -> /, /')
+def step3_dispatch(permuted_local_input_tokens, permuted_probs, input_splits, output_splits):
+    """All-to-all to send tokens to expert-owning ranks.
+    """
+    return permuted_local_input_tokens.clone(), \
+        permuted_probs.clone()
+
+
+@nnscaler.register_op('/, /, /, / -> /, /')
+def step4_dispatch_postprocess(global_input_tokens, global_probs, num_global_tokens_per_local_expert, num_experts, num_local_experts):
+    """Re-sort received tokens so each local expert's tokens are contiguous.
+    """
+    return global_input_tokens.clone(), \
+        global_probs.clone()
+
+
+@nnscaler.register_op('/, E t^ h^, E h^ d^, /, / -> /')
+def step5_compute(global_input_tokens, w13, w2, num_tokens_per_local_expert, global_probs):
+    """Run fused FFN on tokens grouped by local expert.
+    """
+    return global_input_tokens.clone()
+
+
+@nnscaler.register_op('/, /, /, / -> /')
+def step6_compute_postprocess(expert_outs, num_global_tokens_per_local_expert, num_experts, num_local_experts):
+    """Re-sort expert outputs back to per-rank order for all-to-all return.
+    """
+    return expert_outs.clone()
+
+
+@nnscaler.register_op('/, /, / -> /')
+def step7_combine(expert_outs, input_splits, output_splits):
+    """All-to-all to return expert outputs back to source ranks.
+    """
+    return expert_outs.clone()
+
+
+@nnscaler.register_op('l h^, l m^, /, / -> l h^')
+def step8_postprocess(hidden_state, routing_map, permuted_local_input_tokens, reversed_local_input_permutation_mapping):
+    """Unpermute tokens back to original order.
+    """
+    return hidden_state.clone()
+
+
+@nnscaler.register_op('l e^ -> l e^, l e^, l e^')
+def topk_routing(logits, top_k):
+    gate_scores = F.softmax(logits, dim=-1, dtype=torch.float32)
+    scores, top_indices = torch.topk(gate_scores, k=top_k, dim=-1)
+    probs = scores / scores.sum(dim=-1, keepdim=True)
+    routing_probs = torch.zeros_like(logits).scatter(1, top_indices, probs.to(logits.dtype))
+    routing_map = torch.zeros_like(logits).int().scatter(1, top_indices, 1).bool()
+    return routing_probs, routing_map, gate_scores
+
+
+def build_ep_transform_rule():
+    itransform = [
+        DimopSplit.D(0),
+        DimopSplit.D(0),
+        DimopSplit.D(0),
+        DimopSplit.D(0),
+        DimopSplit.D(0),
+    ]
+
+    otransform = [
+        DimopSplit.D(0),
+    ]
+
+    return TransformRule(itransform, otransform)
+
+
+# @nnscaler.register_op(f'l h^, l m^, l m^, E t^ h^, E h^ d^ -> l h^', transform_rules=(build_ep_transform_rule(),))
+def moe_forward(x, routing_map, routing_probs, w13, w2, top_k, num_local_experts, num_experts, ep_size):
+    """
+    It is really tricky to break a function into multiple segments
+    and register them as separate ops.
+    We need to check the generated code to make sure everything is correct.
+
+    We need to be very careful to avoid generating additional adapters or missing necessary adapters
+    Here are some experiences we learned when doing this:
+    1. For sub function annotations, only annotate the inputs and outputs of the whole function.
+       for example, inputs are used in
+        `step1_preprocess`, `step2_permute`, `step5_compute`, `step8_postprocess`
+        and output is returned from `step8_postprocess`
+       All intermediate tensors should be annotated as '/' to make sure no grad reduction adapter is generated.
+
+    2. `y=x.view(*x.shape)` is important if x is splitted in different ways.
+       Here x is used in `self.gate`, which is outside of `moe_forward`.
+       if `self.gate` doesn't split x, but `moe_forward` splits x,
+       then `multiref` will be inserted,
+       and `step2_permute` and `step8_postprocess` will have different version of x,
+       which will cause additional `split_allgather` to be generated for x.
+
+    """
+    y = x.view(*x.shape) # shallow copy to break the autograd graph for x
+
+    # shape: num_tokens_per_local_expert: num_local_experts
+    # num_global_tokens_per_local_expert: (ep_size, num_local_experts)
+    (
+        num_tokens_per_local_expert,
+        num_global_tokens_per_local_expert,
+        input_splits,
+        output_splits,
+    ) = step1_preprocess(
+        routing_map,
+        num_local_experts=num_local_experts,
+        num_experts=num_experts,
+        ep_size=ep_size
+    )
+
+    # shape:
+    # permuted_local_input_tokens: (l topk) h^,
+    # permuted_probs: (l topk),
+    # reversed_local_input_permutation_mapping: (l topk)
+    (
+        permuted_local_input_tokens,
+        permuted_probs,
+        reversed_local_input_permutation_mapping
+    ) = step2_permute(y, routing_map, routing_probs, top_k)
+
+    # shape
+    # global_input_tokens: (l topk) h^,
+    # global_probs: (l topk)
+    (
+        global_input_tokens,
+        global_probs
+    ) = step3_dispatch(permuted_local_input_tokens, permuted_probs, input_splits, output_splits)
+
+    # shape: this shape is fake.
+    # we don't know the exact global shape
+    # global_input_tokens: (l topk) h^,
+    # global_probs: (l topk)
+    (
+        global_input_tokens,
+        global_probs,
+    ) = step4_dispatch_postprocess(global_input_tokens, global_probs, num_global_tokens_per_local_expert, num_experts, 2)
+
+    # shape
+    # global_input_tokens: (l topk) h^,
+    global_input_tokens = step5_compute(global_input_tokens, w13, w2, num_tokens_per_local_expert, global_probs)
+
+    # shape:
+    # expert_outs: (l topk) h^
+    expert_outs = step6_compute_postprocess(global_input_tokens, num_global_tokens_per_local_expert, num_experts, 2)
+
+    # shape:
+    # expert_outs: (l topk) h^
+    expert_outs = step7_combine(expert_outs, input_splits, output_splits)
+
+    # shape:
+    # output: l h^
+    output = step8_postprocess(y, routing_map, expert_outs, reversed_local_input_permutation_mapping)
+
+    return output
+
+
+class MoE(nn.Module):
+    def __init__(
+        self,
+        embed_dim,
+        moe_ffn_dim,
+        num_experts,
+        top_k,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.moe_ffn_dim = moe_ffn_dim
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.ep_size = 2
+        self.num_local_experts = num_experts // self.ep_size
+
+        self.gate = nn.Linear(self.embed_dim, self.num_experts, bias=False, dtype=torch.float32)
+        self.w13 = torch.nn.Parameter(torch.empty((self.num_experts, 2 * self.moe_ffn_dim, self.embed_dim)))
+        self.w2 = torch.nn.Parameter(torch.empty((self.num_experts, self.embed_dim, self.moe_ffn_dim)))
+        self.init_weights()
+
+    def init_weights(self):
+        nn.init.kaiming_uniform_(self.gate.weight, a=math.sqrt(5), mode='fan_in')
+        for i in range(self.num_experts):
+            nn.init.kaiming_uniform_(self.w13[i], a=math.sqrt(5), mode='fan_in')
+            nn.init.kaiming_uniform_(self.w2[i], a=math.sqrt(5), mode='fan_out')
+
+    def forward(self, x):
+        # shape: x: l h^, gate: h^ m^ -> l m^
+        logits = self.gate(x.float())
+        # shape: routing_probs: l m^, routing_map: l m^, gate_scores: l m^
+        routing_probs, routing_map, gate_scores = topk_routing(logits, self.top_k)
+
+        return moe_forward(x, routing_map, routing_probs, self.w13, self.w2,
+                           self.top_k, self.num_local_experts, self.num_experts, self.ep_size)
+
+
+def ep_policy(graph, cfg):
+    from nnscaler.policies import OpPlan, OpPartition
+
+    for node in get_pas_ops(graph):
+        if node.fn == step8_postprocess:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0))
+        elif node.fn == step5_compute:
+            yield OpPlan(node, partition=OpPartition(input=1, dim=0))
+        elif node.fn == step2_permute:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0))
+        elif node.fn == step1_preprocess:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0))
+        elif node.fn == moe_forward:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0))
+
+
+@replace_all_device_with('cpu')
+def test_moe_whole(tmp_path):
+    nnscaler.register_op(
+        f'l h^, l m^, l m^, E t^ h^, E h^ d^ -> l h^',
+        transform_rules=(build_ep_transform_rule(),)
+    )(moe_forward)
+    ep = MoE(embed_dim=32, moe_ffn_dim=64, num_experts=8, top_k=2)
+    h = torch.randn(16, 32)
+
+    nnscaler.parallelize(
+        ep,
+        {'x': h},
+        ep_policy,
+        nnscaler.ComputeConfig(
+            plan_ngpus=2,
+            runtime_ngpus=4,
+        ),
+        gen_savedir=tmp_path,
+        load_module=False
+    )
+    # only x will be multiref'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.function.multiref')) == 1
+    # only x and routing_probs needs to be split_allgather'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.adapter.nn.split_allgather')) == 2
+    # only routing_map needs to be chunk'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.adapter.chunk')) == 1
+    # only output needs to be allgather_split'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.adapter.nn.allgather_split')) == 1
+
+    assert True
+    # def segment107(self, x_25):
+    #     # activation
+    #     x_62, x_63 = nnscaler.runtime.function.multiref(x_25, times=2)
+    #     del x_25
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_register_op.py", line 251, in forward,  logits = self.gate(x.float())
+    #     float_1_27 = torch.Tensor.float(x_62)
+    #     del x_62
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_register_op.py", line 251, in forward,  logits = self.gate(x.float())
+    #     linear_29 = torch.nn.functional.linear(float_1_27, self.gate_weight_28, bias=None)
+    #     del float_1_27
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_register_op.py", line 253, in forward,  routing_probs, routing_map, gate_scores = topk_routing(logits, self.top_k)
+    #     topk_routing_30, topk_routing_31, topk_routing_32 = tests.parallel_module.test_gencode_register_op.topk_routing(linear_29, top_k=2)
+    #     del linear_29, topk_routing_32
+    #     topk_routing_50 = nnscaler.runtime.adapter.nn.split_allgather(topk_routing_30, dim=0, ranks=[0, 1])
+    #     del topk_routing_30
+    #     topk_routing_48 = nnscaler.runtime.adapter.chunk(topk_routing_31, dim=0, ranks=[0, 1])
+    #     del topk_routing_31
+    #     x_66 = nnscaler.runtime.adapter.nn.split_allgather(x_63, dim=0, ranks=[0, 1])
+    #     del x_63
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_register_op.py", line 255, in forward,  return moe_forward(x, routing_map, routing_probs, self.w13, self.w2,
+    #     moe_forward_56 = tests.parallel_module.test_gencode_register_op.moe_forward(x_66, topk_routing_48, topk_routing_50, self.w13_52, self.w2_54, top_k=2, num_local_experts=4, num_experts=8, ep_size=2)
+    #     del topk_routing_50, topk_routing_48, x_66
+    #     moe_forward_26 = nnscaler.runtime.adapter.nn.allgather_split(moe_forward_56, dim=0, ranks=[0, 1])
+    #     del moe_forward_56
+    #     return moe_forward_26
+
+
+@replace_all_device_with('cpu')
+def test_moe_breakdown(tmp_path):
+    from nnscaler.graph.parser.register import CustomizedOps
+    CustomizedOps.kOpMap.pop('tests.parallel_module.test_gencode_ep.moe_forward', None)
+
+    ep = MoE(embed_dim=32, moe_ffn_dim=64, num_experts=8, top_k=2)
+    h = torch.randn(16, 32)
+
+    nnscaler.parallelize(
+        ep,
+        {'x': h},
+        ep_policy,
+        nnscaler.ComputeConfig(
+            plan_ngpus=2,
+            runtime_ngpus=4,
+        ),
+        gen_savedir=tmp_path,
+        load_module=False
+    )
+    # x / routing_map will be multiref'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.function.multiref')) == 2
+    # only x and routing_probs needs to be split_allgather'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.adapter.nn.split_allgather')) == 2
+    # only routing_map needs to be chunk'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.adapter.chunk')) == 1
+    # only output needs to be allgather_split'ed
+    assert len(_gencode_contains(tmp_path, MoE, 0, 'nnscaler.runtime.adapter.nn.allgather_split')) == 1
+
+    # def segment211(self, x_78):
+    #     # created at IRAdapterGener:local_consumer_multiref
+    #     x_148, x_152 = nnscaler.runtime.function.multiref(x_78, times=2)
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 235, in forward,  logits = self.gate(x.float())
+    #     float_1_80 = torch.Tensor.float(x_148)
+    #     del x_148
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 235, in forward,  logits = self.gate(x.float())
+    #     linear_82 = torch.nn.functional.linear(float_1_80, self.gate_weight_81, bias=None)
+    #     del float_1_80
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 237, in forward,  routing_probs, routing_map, gate_scores = topk_routing(logits, self.top_k)
+    #     topk_routing_83, topk_routing_84, topk_routing_85 = tests.parallel_module.test_gencode_ep.topk_routing(linear_82, top_k=2)
+    #     del linear_82, topk_routing_85
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 144, in moe_forward,  y = x.view(*x.shape) # shallow copy to break the autograd graph for x
+    #     im_output_188 = builtins.getattr(x_78, 'shape')
+    #     getattr_3_76 = im_output_188[0]
+    #     getattr_3_77 = im_output_188[1]
+    #     del im_output_188
+    #     del x_78
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 144, in moe_forward,  y = x.view(*x.shape) # shallow copy to break the autograd graph for x
+    #     view_86 = torch.Tensor.view(x_152, size=(getattr_3_76, getattr_3_77))
+    #     del x_152
+    #     topk_routing_122 = nnscaler.runtime.adapter.chunk(topk_routing_84, dim=0, ranks=[0, 1])
+    #     del topk_routing_84
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 148, in moe_forward,  (
+    #     step1_preprocess_87, step1_preprocess_88, step1_preprocess_32, step1_preprocess_35 = tests.parallel_module.test_gencode_ep.step1_preprocess(topk_routing_122, num_local_experts=4, num_experts=8, ep_size=2)
+    #     view_124 = nnscaler.runtime.adapter.nn.split_allgather(view_86, dim=0, ranks=[0, 1])
+    #     del view_86
+    #     # created at IRAdapterGener:local_consumer_multiref
+    #     view_165, view_169 = nnscaler.runtime.function.multiref(view_124, times=2)
+    #     del view_124
+    #     topk_routing_126 = nnscaler.runtime.adapter.nn.split_allgather(topk_routing_83, dim=0, ranks=[0, 1])
+    #     del topk_routing_83
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 164, in moe_forward,  (
+    #     step2_permute_89, step2_permute_90, step2_permute_91 = tests.parallel_module.test_gencode_ep.step2_permute(view_169, topk_routing_122, topk_routing_126, topk=2)
+    #     del view_169, topk_routing_126
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 173, in moe_forward,  (
+    #     step3_dispatch_92, step3_dispatch_93 = tests.parallel_module.test_gencode_ep.step3_dispatch(step2_permute_89, step2_permute_90, input_splits=step1_preprocess_32, output_splits=step1_preprocess_35)
+    #     del step2_permute_89, step2_permute_90
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 182, in moe_forward,  (
+    #     step4_dispatch_postprocess_94, step4_dispatch_postprocess_95 = tests.parallel_module.test_gencode_ep.step4_dispatch_postprocess(step3_dispatch_92, step3_dispatch_93, step1_preprocess_88, 8, num_local_experts=2)
+    #     del step3_dispatch_92, step3_dispatch_93
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 189, in moe_forward,  global_input_tokens = step5_compute(global_input_tokens, w13, w2, num_tokens_per_local_expert, global_probs)
+    #     step5_compute_98 = tests.parallel_module.test_gencode_ep.step5_compute(step4_dispatch_postprocess_94, self.w13_128, self.w2_130, step1_preprocess_87, step4_dispatch_postprocess_95)
+    #     del step1_preprocess_87, step4_dispatch_postprocess_94, step4_dispatch_postprocess_95
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 193, in moe_forward,  expert_outs = step6_compute_postprocess(global_input_tokens, num_global_tokens_per_local_expert, num_experts, 2)
+    #     step6_compute_postprocess_99 = tests.parallel_module.test_gencode_ep.step6_compute_postprocess(step5_compute_98, step1_preprocess_88, 8, 2)
+    #     del step1_preprocess_88, step5_compute_98
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 197, in moe_forward,  expert_outs = step7_combine(expert_outs, input_splits, output_splits)
+    #     step7_combine_100 = tests.parallel_module.test_gencode_ep.step7_combine(step6_compute_postprocess_99, step1_preprocess_32, step1_preprocess_35)
+    #     del step6_compute_postprocess_99
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 201, in moe_forward,  output = step8_postprocess(y, routing_map, expert_outs, reversed_local_input_permutation_mapping)
+    #     step8_postprocess_132 = tests.parallel_module.test_gencode_ep.step8_postprocess(view_165, topk_routing_122, step7_combine_100, step2_permute_91)
+    #     del topk_routing_122, view_165, step2_permute_91, step7_combine_100
+    #     step8_postprocess_79 = nnscaler.runtime.adapter.nn.allgather_split(step8_postprocess_132, dim=0, ranks=[0, 1])
+    #     del step8_postprocess_132
+    #     return step8_postprocess_79
+
+
+def ep_policy_overlap(graph, cfg):
+    from nnscaler.policies import OpPlan, OpPartition
+
+    stage = 0
+    # step0 ~ step2: stage=0
+    # dispatch(step 3) stage=1
+    # dispatch_postprocess(step 4) ~ step6: stage=2
+    # combine(step 7) stage=3
+    # step 8 ~ end: stage=4
+    for node in get_pas_ops(graph):
+        if node.fn == step8_postprocess:
+            stage += 1
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0), stage_id=stage)
+        elif node.fn == step7_combine:
+            stage += 1
+            yield OpPlan(node, stage_id=stage)
+        elif node.fn == step5_compute:
+            yield OpPlan(node, partition=OpPartition(input=1, dim=0), stage_id=stage)
+        elif node.fn == step4_dispatch_postprocess:
+            stage += 1
+            yield OpPlan(node, stage_id=stage)
+        elif node.fn == step3_dispatch:
+            stage += 1
+            yield OpPlan(node, stage_id=stage)
+        elif node.fn == step2_permute:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0), stage_id=stage)
+        elif node.fn == step1_preprocess:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0), stage_id=stage)
+        elif node.fn == moe_forward:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0), stage_id=stage)
+        else:
+            yield OpPlan(node, stage_id=stage)
+
+
+def sched_overlap(graph: IRGraph, num_microbatches: int, num_stages: int) -> SchedulePlan:
+    """
+    1F1B overlapped schedule with two CUDA streams.
+
+    Warmup:   full forward  mb 0
+    1F1B:     for i in 1..N-1  →  forward(mb_i) interleaved with backward(mb_{i-1})
+    Cooldown: full backward  mb N-1
+
+    Within each 1F1B step the interleaving pairs forward and backward segments
+    that land on *different* streams so they truly execute concurrently:
+
+        comp_stream: fwd0 │ bwd4 │ fwd2 │ bwd2 │ fwd4 │ bwd0
+        comm_stream:      │ fwd1 │ bwd3 │ fwd3 │ bwd1 │
+                          ↕      ↕      ↕      ↕
+                       overlap overlap overlap overlap
+
+    Each stream waits for the other stream's previous event at pair boundaries.
+    """
+
+    if num_microbatches != 4:
+        raise ValueError("This toy schedule is hard-coded for num_microbatches=4")
+    if num_stages != 5:
+        raise ValueError("This toy schedule is hard-coded for num_stages=5")
+
+    segments: List[IRSegment] = graph.select(ntype=IRSegment, flatten=False)
+    fsegs = [seg for seg in segments if seg.isfw()]
+    assert len(fsegs) == num_stages, f"Mismatch of forward segment number ({len(fsegs)}) with num_stages ({num_stages})"
+
+    # describe schedule
+    sched = SchedulePlan(graph, num_microbatches)
+    comm_sc = StreamContext(stream='comm',wait_streams=['comp'])
+    comp_sc = StreamContext(stream='comp', wait_streams=['comm'])
+    forward_event = 'forward'
+    backward_event = 'backward'
+
+    fseg_stream_name = ['comp', 'comm', 'comp', 'comm', 'comp']
+    sched.stream_config = StreamConfig(
+        dataloader=comp_sc,
+        zero_grad=comp_sc,
+        inter_segment_move=comm_sc,
+        result_broadcast=comm_sc,
+        grad_reduce=comm_sc,
+    )
+    # warm up: full forward of mb 0
+    for sid in range(num_stages):
+        sched.add_segment(fsegs[sid], 0, step=sid,
+            stream_context=StreamContext(stream='comp',wait_streams=['comm'], record_events=[forward_event])
+            if sid == 0 else
+            StreamContext(stream=fseg_stream_name[sid], wait_events=[forward_event], record_events=[forward_event])
+        )
+
+    # 1F1B: forward(i) + backward(i-1)
+    backward_event_recorded = False
+    for micro_idx in range(1, num_microbatches):
+        # Phase 1: fwd_seg0 alone on comp_stream
+        sid += 1
+        sched.add_segment(fsegs[0], micro_idx, step=sid,
+            stream_context=StreamContext(stream='comp',wait_streams=['comm'], record_events=[forward_event])
+        )
+
+        # Phase 2-5: overlapping pairs
+        for fwd_s, bwd_s in [(1, 4), (2, 3), (3, 2), (4, 1)]:
+            sid += 1
+            sched.add_segment(fsegs[fwd_s], micro_idx, step=sid,
+                    stream_context=StreamContext(
+                    stream=fseg_stream_name[fwd_s], record_events=[forward_event], wait_events=[forward_event]
+                )
+            )
+            sid += 1
+            sched.add_segment(fsegs[bwd_s].mirror, micro_idx - 1, step=sid,
+                    stream_context=StreamContext(
+                    stream=fseg_stream_name[bwd_s],
+                    record_events=[backward_event],
+                    wait_events=[backward_event] if backward_event_recorded else []
+                )
+            )
+            backward_event_recorded = True
+
+        # Phase 6: bwd_seg0 alone on comp_stream
+        sid += 1
+        sched.add_segment(fsegs[0].mirror, micro_idx - 1, step=sid,
+                stream_context=StreamContext(
+                stream=fseg_stream_name[0], record_events=[backward_event], wait_events=[backward_event]
+            )
+        )
+
+    # Cooldown: backward last mb
+    for stage in reversed(range(num_stages)):
+        sid += 1
+        sched.add_segment(fsegs[stage].mirror, num_microbatches - 1, step=sid,
+            stream_context=
+                StreamContext(stream='comp',wait_streams=['comm'], record_events=[backward_event])
+                if stage == num_stages - 1 else
+                StreamContext(stream=fseg_stream_name[stage], wait_events=[backward_event], record_events=[backward_event])
+        )
+
+    sched.finish()
+    return sched
+
+
+class MoeWithLoss(torch.nn.Module):
+    def __init__(self, embed_dim, moe_ffn_dim, num_experts, top_k):
+        super().__init__()
+        self.moe = MoE(embed_dim, moe_ffn_dim, num_experts, top_k)
+
+    def forward(self, x):
+        output = self.moe(x)
+        loss = torch.sum(output)
+        return loss
+
+
+@replace_all_device_with('cpu')
+def test_moe_breakdown_overlap(tmp_path):
+    ep = MoeWithLoss(embed_dim=32, moe_ffn_dim=64, num_experts=8, top_k=2)
+    h = torch.randn(16, 32)
+
+    nnscaler.parallelize(
+        ep,
+        {'x': h},
+        ep_policy_overlap,
+        nnscaler.ComputeConfig(
+            plan_ngpus=2,
+            runtime_ngpus=4,
+            use_end2end=True,
+            pas_config={
+                'pipeline_nmicros': 4,
+                'pipeline_size': 1,
+                'pipeline_scheduler': sched_overlap
+            }
+        ),
+        gen_savedir=tmp_path,
+        load_module=False
+    )
+    assert True  # should success
+
+    # def segment54(self, x_65):
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 235, in forward,  logits = self.gate(x.float())
+    #     float_1_67 = torch.Tensor.float(x_65)
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 235, in forward,  logits = self.gate(x.float())
+    #     linear_69 = torch.nn.functional.linear(float_1_67, self.moe_gate_weight_68, bias=None)
+    #     del float_1_67
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 237, in forward,  routing_probs, routing_map, gate_scores = topk_routing(logits, self.top_k)
+    #     topk_routing_70, topk_routing_71, topk_routing_72 = tests.parallel_module.test_gencode_ep.topk_routing(linear_69, top_k=2)
+    #     del linear_69, topk_routing_72
+    #     # create at IRAdapterGener:autoref, comment before transformation: activation
+    #     topk_routing_161, topk_routing_162 = nnscaler.runtime.function.multiref(topk_routing_71, times=2)
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 144, in moe_forward,  y = x.view(*x.shape) # shallow copy to break the autograd graph for x
+    #     im_output_479 = builtins.getattr(x_65, 'shape')
+    #     getattr_3_63 = im_output_479[0]
+    #     getattr_3_64 = im_output_479[1]
+    #     del im_output_479
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 144, in moe_forward,  y = x.view(*x.shape) # shallow copy to break the autograd graph for x
+    #     view_73 = torch.Tensor.view(x_65, size=(getattr_3_63, getattr_3_64))
+    #     del x_65
+    #     # create at IRAdapterGener:autoref, comment before transformation: activation
+    #     view_164 = nnscaler.runtime.function.multiref(view_73, times=1)
+    #     topk_routing_165 = nnscaler.runtime.adapter.chunk(topk_routing_161, dim=0, ranks=[0, 1])
+    #     del topk_routing_161
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 148, in moe_forward,  (
+    #     step1_preprocess_74, step1_preprocess_75, step1_preprocess_29, step1_preprocess_32 = tests.parallel_module.test_gencode_ep.step1_preprocess(topk_routing_165, num_local_experts=4, num_experts=8, ep_size=2)
+    #     del topk_routing_165
+    #     topk_routing_99 = nnscaler.runtime.adapter.nn.split_allgather(topk_routing_70, dim=0, ranks=[0, 1])
+    #     del topk_routing_70
+    #     topk_routing_169 = nnscaler.runtime.adapter.chunk(topk_routing_162, dim=0, ranks=[0, 1])
+    #     del topk_routing_162
+    #     view_167 = nnscaler.runtime.adapter.chunk(view_164, dim=0, ranks=[0, 1])
+    #     del view_164
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 164, in moe_forward,  (
+    #     step2_permute_76, step2_permute_77, step2_permute_78 = tests.parallel_module.test_gencode_ep.step2_permute(view_167, topk_routing_169, topk_routing_99, topk=2)
+    #     del topk_routing_99, topk_routing_169, view_167
+    #     return topk_routing_71, view_73, step1_preprocess_74, step1_preprocess_75, step1_preprocess_29, step1_preprocess_32, step2_permute_76, step2_permute_77, step2_permute_78
+
+    # def segment59(self, topk_routing_71, view_73, step1_preprocess_74, step1_preprocess_75, step1_preprocess_29, step1_preprocess_32, step2_permute_76, step2_permute_77, step2_permute_78):
+    #     step2_permute_137 = nnscaler.runtime.function.identity(step2_permute_78)
+    #     del step2_permute_78
+    #     step2_permute_134 = nnscaler.runtime.function.identity(step2_permute_77)
+    #     del step2_permute_77
+    #     step2_permute_132 = nnscaler.runtime.function.identity(step2_permute_76)
+    #     del step2_permute_76
+    #     step1_preprocess_128 = nnscaler.runtime.function.identity(step1_preprocess_75)
+    #     del step1_preprocess_75
+    #     step1_preprocess_124 = nnscaler.runtime.function.identity(step1_preprocess_74)
+    #     del step1_preprocess_74
+    #     view_116 = nnscaler.runtime.function.identity(view_73)
+    #     del view_73
+    #     topk_routing_108 = nnscaler.runtime.function.identity(topk_routing_71)
+    #     del topk_routing_71
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 173, in moe_forward,  (
+    #     step3_dispatch_79, step3_dispatch_80 = tests.parallel_module.test_gencode_ep.step3_dispatch(step2_permute_132, step2_permute_134, input_splits=step1_preprocess_29, output_splits=step1_preprocess_32)
+    #     del step2_permute_134, step2_permute_132
+    #     return step3_dispatch_79, step3_dispatch_80, topk_routing_108, view_116, step1_preprocess_124, step1_preprocess_128, step2_permute_137
+
+    # def segment62(self, step3_dispatch_79, step3_dispatch_80, topk_routing_108, view_116, step1_preprocess_124, step1_preprocess_128, step2_permute_137):
+    #     step3_dispatch_154 = nnscaler.runtime.function.identity(step3_dispatch_80)
+    #     del step3_dispatch_80
+    #     step3_dispatch_152 = nnscaler.runtime.function.identity(step3_dispatch_79)
+    #     del step3_dispatch_79
+    #     step2_permute_141 = nnscaler.runtime.function.identity(step2_permute_137)
+    #     del step2_permute_137
+    #     step1_preprocess_130 = nnscaler.runtime.function.identity(step1_preprocess_128)
+    #     del step1_preprocess_128
+    #     step1_preprocess_126 = nnscaler.runtime.function.identity(step1_preprocess_124)
+    #     del step1_preprocess_124
+    #     view_118 = nnscaler.runtime.function.identity(view_116)
+    #     del view_116
+    #     topk_routing_110 = nnscaler.runtime.function.identity(topk_routing_108)
+    #     del topk_routing_108
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 182, in moe_forward,  (
+    #     step4_dispatch_postprocess_81, step4_dispatch_postprocess_82 = tests.parallel_module.test_gencode_ep.step4_dispatch_postprocess(step3_dispatch_152, step3_dispatch_154, step1_preprocess_130, 8, num_local_experts=2)
+    #     del step3_dispatch_154, step3_dispatch_152
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 189, in moe_forward,  global_input_tokens = step5_compute(global_input_tokens, w13, w2, num_tokens_per_local_expert, global_probs)
+    #     step5_compute_85 = tests.parallel_module.test_gencode_ep.step5_compute(step4_dispatch_postprocess_81, self.moe_w13_101, self.moe_w2_103, step1_preprocess_126, step4_dispatch_postprocess_82)
+    #     del step1_preprocess_126, step4_dispatch_postprocess_81, step4_dispatch_postprocess_82
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 193, in moe_forward,  expert_outs = step6_compute_postprocess(global_input_tokens, num_global_tokens_per_local_expert, num_experts, 2)
+    #     step6_compute_postprocess_86 = tests.parallel_module.test_gencode_ep.step6_compute_postprocess(step5_compute_85, step1_preprocess_130, 8, 2)
+    #     del step1_preprocess_130, step5_compute_85
+    #     return step6_compute_postprocess_86, topk_routing_110, view_118, step2_permute_141
+
+    # def segment65(self, step1_preprocess_29, step1_preprocess_32, step6_compute_postprocess_86, topk_routing_110, view_118, step2_permute_141):
+    #     step6_compute_postprocess_156 = nnscaler.runtime.function.identity(step6_compute_postprocess_86)
+    #     del step6_compute_postprocess_86
+    #     step2_permute_145 = nnscaler.runtime.function.identity(step2_permute_141)
+    #     del step2_permute_141
+    #     view_120 = nnscaler.runtime.function.identity(view_118)
+    #     del view_118
+    #     topk_routing_112 = nnscaler.runtime.function.identity(topk_routing_110)
+    #     del topk_routing_110
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 197, in moe_forward,  expert_outs = step7_combine(expert_outs, input_splits, output_splits)
+    #     step7_combine_87 = tests.parallel_module.test_gencode_ep.step7_combine(step6_compute_postprocess_156, step1_preprocess_29, step1_preprocess_32)
+    #     del step6_compute_postprocess_156
+    #     return step7_combine_87, topk_routing_112, view_120, step2_permute_145
+
+    # def segment68(self, step7_combine_87, topk_routing_112, view_120, step2_permute_145):
+    #     step7_combine_158 = nnscaler.runtime.function.identity(step7_combine_87)
+    #     del step7_combine_87
+    #     step2_permute_149 = nnscaler.runtime.function.identity(step2_permute_145)
+    #     del step2_permute_145
+    #     view_122 = nnscaler.runtime.function.identity(view_120)
+    #     del view_120
+    #     topk_routing_114 = nnscaler.runtime.function.identity(topk_routing_112)
+    #     del topk_routing_112
+    #     topk_routing_175 = nnscaler.runtime.adapter.chunk(topk_routing_114, dim=0, ranks=[0, 1])
+    #     del topk_routing_114
+    #     view_173 = nnscaler.runtime.adapter.chunk(view_122, dim=0, ranks=[0, 1])
+    #     del view_122
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 201, in moe_forward,  output = step8_postprocess(y, routing_map, expert_outs, reversed_local_input_permutation_mapping)
+    #     step8_postprocess_105 = tests.parallel_module.test_gencode_ep.step8_postprocess(view_173, topk_routing_175, step7_combine_158, step2_permute_149)
+    #     del step7_combine_158, step2_permute_149, topk_routing_175, view_173
+    #     step8_postprocess_88 = nnscaler.runtime.adapter.all_gather(step8_postprocess_105, dim=0, ranks=[0, 1])
+    #     del step8_postprocess_105
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_ep.py", line 543, in forward,  loss = torch.sum(output)
+    #     sum_1_66 = torch.sum(step8_postprocess_88)
+    #     del step8_postprocess_88
+    #     return sum_1_66
+
+    # def _train_step(model, dataloader_89):
+    #     _ = None
+    #     nnscaler.flags.RuntimeFlag.skip_zero_grad = False
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         model.zero_grad()
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_65 = next(*(dataloader_89, ))
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_65.record_stream(torch.cuda.current_stream())
+    #         topk_routing_71, view_73, step1_preprocess_74, step1_preprocess_75, step1_preprocess_29, step1_preprocess_32, step2_permute_76, step2_permute_77, step2_permute_78 = nnscaler.runtime.executor.fexecute('segment54', model.segment54, *(x_65, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del x_65
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         topk_routing_71.record_stream(torch.cuda.current_stream())
+    #         view_73.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_74.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_75.record_stream(torch.cuda.current_stream())
+    #         step2_permute_76.record_stream(torch.cuda.current_stream())
+    #         step2_permute_77.record_stream(torch.cuda.current_stream())
+    #         step2_permute_78.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_79, step3_dispatch_80, topk_routing_108, view_116, step1_preprocess_124, step1_preprocess_128, step2_permute_137 = nnscaler.runtime.executor.fexecute('segment59', model.segment59, *(topk_routing_71, view_73, step1_preprocess_74, step1_preprocess_75, step1_preprocess_29, step1_preprocess_32, step2_permute_76, step2_permute_77, step2_permute_78, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del topk_routing_71, view_73, step1_preprocess_74, step1_preprocess_75, step2_permute_76, step2_permute_77
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step3_dispatch_79.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_80.record_stream(torch.cuda.current_stream())
+    #         topk_routing_108.record_stream(torch.cuda.current_stream())
+    #         view_116.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_124.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_128.record_stream(torch.cuda.current_stream())
+    #         step2_permute_137.record_stream(torch.cuda.current_stream())
+    #         step6_compute_postprocess_86, topk_routing_110, view_118, step2_permute_141 = nnscaler.runtime.executor.fexecute('segment62', model.segment62, *(step3_dispatch_79, step3_dispatch_80, topk_routing_108, view_116, step1_preprocess_124, step1_preprocess_128, step2_permute_137, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step3_dispatch_79, step3_dispatch_80, topk_routing_108, view_116, step1_preprocess_124, step1_preprocess_128
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step6_compute_postprocess_86.record_stream(torch.cuda.current_stream())
+    #         topk_routing_110.record_stream(torch.cuda.current_stream())
+    #         view_118.record_stream(torch.cuda.current_stream())
+    #         step2_permute_141.record_stream(torch.cuda.current_stream())
+    #         step7_combine_87, topk_routing_112, view_120, step2_permute_145 = nnscaler.runtime.executor.fexecute('segment65', model.segment65, *(step1_preprocess_29, step1_preprocess_32, step6_compute_postprocess_86, topk_routing_110, view_118, step2_permute_141, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step6_compute_postprocess_86, topk_routing_110, view_118
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step7_combine_87.record_stream(torch.cuda.current_stream())
+    #         topk_routing_112.record_stream(torch.cuda.current_stream())
+    #         view_120.record_stream(torch.cuda.current_stream())
+    #         step2_permute_145.record_stream(torch.cuda.current_stream())
+    #         sum_1_66 = nnscaler.runtime.executor.fexecute('segment68', model.segment68, *(step7_combine_87, topk_routing_112, view_120, step2_permute_145, ), requires_grad=False)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step7_combine_87, topk_routing_112, view_120
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_186 = next(*(dataloader_89, ))
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_186.record_stream(torch.cuda.current_stream())
+    #         topk_routing_190, view_192, step1_preprocess_194, step1_preprocess_196, step1_preprocess_197, step1_preprocess_198, step2_permute_200, step2_permute_202, step2_permute_205 = nnscaler.runtime.executor.fexecute('segment54', model.segment54, *(x_186, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del x_186
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         topk_routing_190.record_stream(torch.cuda.current_stream())
+    #         view_192.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_194.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_196.record_stream(torch.cuda.current_stream())
+    #         step2_permute_200.record_stream(torch.cuda.current_stream())
+    #         step2_permute_202.record_stream(torch.cuda.current_stream())
+    #         step2_permute_205.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_219, step3_dispatch_221, topk_routing_223, view_225, step1_preprocess_227, step1_preprocess_229, step2_permute_232 = nnscaler.runtime.executor.fexecute('segment59', model.segment59, *(topk_routing_190, view_192, step1_preprocess_194, step1_preprocess_196, step1_preprocess_197, step1_preprocess_198, step2_permute_200, step2_permute_202, step2_permute_205, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del topk_routing_190, view_192, step1_preprocess_194, step1_preprocess_196, step2_permute_200, step2_permute_202
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         _ = nnscaler.runtime.executor.backward('segment68', (), (), ())
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step3_dispatch_219.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_221.record_stream(torch.cuda.current_stream())
+    #         topk_routing_223.record_stream(torch.cuda.current_stream())
+    #         view_225.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_227.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_229.record_stream(torch.cuda.current_stream())
+    #         step2_permute_232.record_stream(torch.cuda.current_stream())
+    #         step6_compute_postprocess_245, topk_routing_247, view_249, step2_permute_252 = nnscaler.runtime.executor.fexecute('segment62', model.segment62, *(step3_dispatch_219, step3_dispatch_221, topk_routing_223, view_225, step1_preprocess_227, step1_preprocess_229, step2_permute_232, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step3_dispatch_219, step3_dispatch_221, topk_routing_223, view_225, step1_preprocess_227, step1_preprocess_229
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_141.record_stream(torch.cuda.current_stream())
+    #         step2_permute_145.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_146.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_142 = nnscaler.runtime.executor.backward('segment65', (step2_permute_141, ), (step2_permute_145, ), (gstep2_permute_146, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_145, gstep2_permute_146
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step6_compute_postprocess_245.record_stream(torch.cuda.current_stream())
+    #         topk_routing_247.record_stream(torch.cuda.current_stream())
+    #         view_249.record_stream(torch.cuda.current_stream())
+    #         step2_permute_252.record_stream(torch.cuda.current_stream())
+    #         step7_combine_264, topk_routing_266, view_268, step2_permute_271 = nnscaler.runtime.executor.fexecute('segment65', model.segment65, *(step1_preprocess_197, step1_preprocess_198, step6_compute_postprocess_245, topk_routing_247, view_249, step2_permute_252, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step6_compute_postprocess_245, topk_routing_247, view_249
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_137.record_stream(torch.cuda.current_stream())
+    #         step2_permute_141.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_142.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_138 = nnscaler.runtime.executor.backward('segment62', (step2_permute_137, ), (step2_permute_141, ), (gstep2_permute_142, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_141, gstep2_permute_142
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step7_combine_264.record_stream(torch.cuda.current_stream())
+    #         topk_routing_266.record_stream(torch.cuda.current_stream())
+    #         view_268.record_stream(torch.cuda.current_stream())
+    #         step2_permute_271.record_stream(torch.cuda.current_stream())
+    #         sum_1_281 = nnscaler.runtime.executor.fexecute('segment68', model.segment68, *(step7_combine_264, topk_routing_266, view_268, step2_permute_271, ), requires_grad=False)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step7_combine_264, topk_routing_266, view_268
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_78.record_stream(torch.cuda.current_stream())
+    #         step2_permute_137.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_138.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_94 = nnscaler.runtime.executor.backward('segment59', (step2_permute_78, ), (step2_permute_137, ), (gstep2_permute_138, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_137, gstep2_permute_138
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_78.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_94.record_stream(torch.cuda.current_stream())
+    #         _ = nnscaler.runtime.executor.backward('segment54', (), (step2_permute_78, ), (gstep2_permute_94, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_78, gstep2_permute_94
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_283 = next(*(dataloader_89, ))
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_283.record_stream(torch.cuda.current_stream())
+    #         topk_routing_287, view_289, step1_preprocess_291, step1_preprocess_293, step1_preprocess_294, step1_preprocess_295, step2_permute_297, step2_permute_299, step2_permute_302 = nnscaler.runtime.executor.fexecute('segment54', model.segment54, *(x_283, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del x_283
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         topk_routing_287.record_stream(torch.cuda.current_stream())
+    #         view_289.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_291.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_293.record_stream(torch.cuda.current_stream())
+    #         step2_permute_297.record_stream(torch.cuda.current_stream())
+    #         step2_permute_299.record_stream(torch.cuda.current_stream())
+    #         step2_permute_302.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_316, step3_dispatch_318, topk_routing_320, view_322, step1_preprocess_324, step1_preprocess_326, step2_permute_329 = nnscaler.runtime.executor.fexecute('segment59', model.segment59, *(topk_routing_287, view_289, step1_preprocess_291, step1_preprocess_293, step1_preprocess_294, step1_preprocess_295, step2_permute_297, step2_permute_299, step2_permute_302, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del topk_routing_287, view_289, step1_preprocess_291, step1_preprocess_293, step2_permute_297, step2_permute_299
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         _ = nnscaler.runtime.executor.backward('segment68', (), (), ())
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step3_dispatch_316.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_318.record_stream(torch.cuda.current_stream())
+    #         topk_routing_320.record_stream(torch.cuda.current_stream())
+    #         view_322.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_324.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_326.record_stream(torch.cuda.current_stream())
+    #         step2_permute_329.record_stream(torch.cuda.current_stream())
+    #         step6_compute_postprocess_342, topk_routing_344, view_346, step2_permute_349 = nnscaler.runtime.executor.fexecute('segment62', model.segment62, *(step3_dispatch_316, step3_dispatch_318, topk_routing_320, view_322, step1_preprocess_324, step1_preprocess_326, step2_permute_329, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step3_dispatch_316, step3_dispatch_318, topk_routing_320, view_322, step1_preprocess_324, step1_preprocess_326
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_252.record_stream(torch.cuda.current_stream())
+    #         step2_permute_271.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_272.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_253 = nnscaler.runtime.executor.backward('segment65', (step2_permute_252, ), (step2_permute_271, ), (gstep2_permute_272, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_271, gstep2_permute_272
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step6_compute_postprocess_342.record_stream(torch.cuda.current_stream())
+    #         topk_routing_344.record_stream(torch.cuda.current_stream())
+    #         view_346.record_stream(torch.cuda.current_stream())
+    #         step2_permute_349.record_stream(torch.cuda.current_stream())
+    #         step7_combine_361, topk_routing_363, view_365, step2_permute_368 = nnscaler.runtime.executor.fexecute('segment65', model.segment65, *(step1_preprocess_294, step1_preprocess_295, step6_compute_postprocess_342, topk_routing_344, view_346, step2_permute_349, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step6_compute_postprocess_342, topk_routing_344, view_346
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_232.record_stream(torch.cuda.current_stream())
+    #         step2_permute_252.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_253.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_233 = nnscaler.runtime.executor.backward('segment62', (step2_permute_232, ), (step2_permute_252, ), (gstep2_permute_253, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_252, gstep2_permute_253
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step7_combine_361.record_stream(torch.cuda.current_stream())
+    #         topk_routing_363.record_stream(torch.cuda.current_stream())
+    #         view_365.record_stream(torch.cuda.current_stream())
+    #         step2_permute_368.record_stream(torch.cuda.current_stream())
+    #         sum_1_378 = nnscaler.runtime.executor.fexecute('segment68', model.segment68, *(step7_combine_361, topk_routing_363, view_365, step2_permute_368, ), requires_grad=False)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step7_combine_361, topk_routing_363, view_365
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_205.record_stream(torch.cuda.current_stream())
+    #         step2_permute_232.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_233.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_206 = nnscaler.runtime.executor.backward('segment59', (step2_permute_205, ), (step2_permute_232, ), (gstep2_permute_233, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_232, gstep2_permute_233
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_205.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_206.record_stream(torch.cuda.current_stream())
+    #         _ = nnscaler.runtime.executor.backward('segment54', (), (step2_permute_205, ), (gstep2_permute_206, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_205, gstep2_permute_206
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_380 = next(*(dataloader_89, ))
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         x_380.record_stream(torch.cuda.current_stream())
+    #         topk_routing_384, view_386, step1_preprocess_388, step1_preprocess_390, step1_preprocess_391, step1_preprocess_392, step2_permute_394, step2_permute_396, step2_permute_399 = nnscaler.runtime.executor.fexecute('segment54', model.segment54, *(x_380, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del x_380
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         topk_routing_384.record_stream(torch.cuda.current_stream())
+    #         view_386.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_388.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_390.record_stream(torch.cuda.current_stream())
+    #         step2_permute_394.record_stream(torch.cuda.current_stream())
+    #         step2_permute_396.record_stream(torch.cuda.current_stream())
+    #         step2_permute_399.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_413, step3_dispatch_415, topk_routing_417, view_419, step1_preprocess_421, step1_preprocess_423, step2_permute_426 = nnscaler.runtime.executor.fexecute('segment59', model.segment59, *(topk_routing_384, view_386, step1_preprocess_388, step1_preprocess_390, step1_preprocess_391, step1_preprocess_392, step2_permute_394, step2_permute_396, step2_permute_399, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del topk_routing_384, view_386, step1_preprocess_388, step1_preprocess_390, step2_permute_394, step2_permute_396
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         _ = nnscaler.runtime.executor.backward('segment68', (), (), ())
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step3_dispatch_413.record_stream(torch.cuda.current_stream())
+    #         step3_dispatch_415.record_stream(torch.cuda.current_stream())
+    #         topk_routing_417.record_stream(torch.cuda.current_stream())
+    #         view_419.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_421.record_stream(torch.cuda.current_stream())
+    #         step1_preprocess_423.record_stream(torch.cuda.current_stream())
+    #         step2_permute_426.record_stream(torch.cuda.current_stream())
+    #         step6_compute_postprocess_439, topk_routing_441, view_443, step2_permute_446 = nnscaler.runtime.executor.fexecute('segment62', model.segment62, *(step3_dispatch_413, step3_dispatch_415, topk_routing_417, view_419, step1_preprocess_421, step1_preprocess_423, step2_permute_426, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step3_dispatch_413, step3_dispatch_415, topk_routing_417, view_419, step1_preprocess_421, step1_preprocess_423
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_349.record_stream(torch.cuda.current_stream())
+    #         step2_permute_368.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_369.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_350 = nnscaler.runtime.executor.backward('segment65', (step2_permute_349, ), (step2_permute_368, ), (gstep2_permute_369, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_368, gstep2_permute_369
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step6_compute_postprocess_439.record_stream(torch.cuda.current_stream())
+    #         topk_routing_441.record_stream(torch.cuda.current_stream())
+    #         view_443.record_stream(torch.cuda.current_stream())
+    #         step2_permute_446.record_stream(torch.cuda.current_stream())
+    #         step7_combine_458, topk_routing_460, view_462, step2_permute_465 = nnscaler.runtime.executor.fexecute('segment65', model.segment65, *(step1_preprocess_391, step1_preprocess_392, step6_compute_postprocess_439, topk_routing_441, view_443, step2_permute_446, ), requires_grad=True)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step6_compute_postprocess_439, topk_routing_441, view_443
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_329.record_stream(torch.cuda.current_stream())
+    #         step2_permute_349.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_350.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_330 = nnscaler.runtime.executor.backward('segment62', (step2_permute_329, ), (step2_permute_349, ), (gstep2_permute_350, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_349, gstep2_permute_350
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').wait()
+    #         step7_combine_458.record_stream(torch.cuda.current_stream())
+    #         topk_routing_460.record_stream(torch.cuda.current_stream())
+    #         view_462.record_stream(torch.cuda.current_stream())
+    #         step2_permute_465.record_stream(torch.cuda.current_stream())
+    #         sum_1_475 = nnscaler.runtime.executor.fexecute('segment68', model.segment68, *(step7_combine_458, topk_routing_460, view_462, step2_permute_465, ), requires_grad=False)
+    #         nnscaler.runtime.device.DeviceGroup().get_event('forward').record()
+
+    #     del step7_combine_458, topk_routing_460, view_462
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_302.record_stream(torch.cuda.current_stream())
+    #         step2_permute_329.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_330.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_303 = nnscaler.runtime.executor.backward('segment59', (step2_permute_302, ), (step2_permute_329, ), (gstep2_permute_330, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_329, gstep2_permute_330
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = True
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_302.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_303.record_stream(torch.cuda.current_stream())
+    #         _ = nnscaler.runtime.executor.backward('segment54', (), (step2_permute_302, ), (gstep2_permute_303, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_302, gstep2_permute_303
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = False
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm'))
+    #         _ = nnscaler.runtime.executor.backward('segment68', (), (), ())
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = False
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_446.record_stream(torch.cuda.current_stream())
+    #         step2_permute_465.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_466.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_447 = nnscaler.runtime.executor.backward('segment65', (step2_permute_446, ), (step2_permute_465, ), (gstep2_permute_466, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_465, gstep2_permute_466
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = False
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_426.record_stream(torch.cuda.current_stream())
+    #         step2_permute_446.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_447.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_427 = nnscaler.runtime.executor.backward('segment62', (step2_permute_426, ), (step2_permute_446, ), (gstep2_permute_447, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_446, gstep2_permute_447
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = False
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_399.record_stream(torch.cuda.current_stream())
+    #         step2_permute_426.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_427.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_400 = nnscaler.runtime.executor.backward('segment59', (step2_permute_399, ), (step2_permute_426, ), (gstep2_permute_427, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_426, gstep2_permute_427
+    #     nnscaler.flags.RuntimeFlag.skip_reducer = False
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp')):
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').wait()
+    #         step2_permute_399.record_stream(torch.cuda.current_stream())
+    #         gstep2_permute_400.record_stream(torch.cuda.current_stream())
+    #         _ = nnscaler.runtime.executor.backward('segment54', (), (step2_permute_399, ), (gstep2_permute_400, ))
+    #         nnscaler.runtime.device.DeviceGroup().get_event('backward').record()
+
+    #     del step2_permute_399, gstep2_permute_400
+
+    #     with torch.cuda.stream(nnscaler.runtime.device.DeviceGroup().get_stream('comm')):
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp'))
+    #         _ = nnscaler.runtime.executor.aexecute(model.reducer732, *(), requires_grad=False)
+    #         torch.cuda.current_stream().wait_stream(nnscaler.runtime.device.DeviceGroup().get_stream('comp'))
+    #         _ = nnscaler.runtime.executor.aexecute(model.reducer733, *(), requires_grad=False)
+
+    #     return sum_1_66, sum_1_281, sum_1_378, sum_1_475

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -42,7 +42,7 @@ def test_rope_buggy_anno(tmp_path):
         load_module=False,
         reuse='override',
     )
-    # because of the bad annoation, a wrong grad allreduce is inserted
+    # because of the bad annotation, a wrong grad allreduce is inserted
     assert _gencode_contains(tmp_path, RopeModel, 0, r'nnscaler.runtime.adapter.nn.identity_allreduce')
     # def segment143(self, x_44, cos_45, sin_46, position_ids_47):
     #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 42, in forward,  bsz, seq_len, hidden_dim = x.shape

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -1,0 +1,202 @@
+import torch
+
+from nnscaler import parallelize, ComputeConfig
+import nnscaler
+
+from tests.autodist.spmd_solver.test_follow import apply_rotary_pos_emb, Model as RopeModel
+from tests.parallel_module.test_gencode import replace_all_device_with, _gencode_contains
+
+
+def rope_m_policy(graph, cfg):
+    from nnscaler.policies import OpPlan, OpPartition, get_pas_ops
+
+    for node in get_pas_ops(graph):
+        if node.fn == apply_rotary_pos_emb:
+            # split the `m` dimension
+            yield OpPlan(node, partition=OpPartition(input=1, dim=1))
+
+
+@replace_all_device_with('cpu')
+def test_rope_buggy_anno(tmp_path):
+    from nnscaler.graph.parser.register import CustomizedOps
+    CustomizedOps.kOpMap.pop('tests.autodist.spmd_solver.test_follow.apply_rotary_pos_emb', None)
+    nnscaler.register_op('b h s^ d^, b m s^ d^, s^ d^, s^ d^, s^ -> b h s^ d^, b m s^ d^')(apply_rotary_pos_emb)
+
+    bsz, seq_len, head_num, hidden_dim = 2, 128, 8, 512
+    head_dim = hidden_dim // head_num
+    dummy_input = {
+        'x': torch.rand(bsz, seq_len, hidden_dim),
+        'cos': torch.rand(seq_len, head_dim),
+        'sin': torch.rand(seq_len, head_dim),
+        'position_ids': torch.arange(seq_len, dtype=torch.long),
+    }
+    m = RopeModel(head_num, hidden_dim)
+
+    m.train()
+    m_new = parallelize(
+        m,
+        dummy_input,
+        rope_m_policy,
+        ComputeConfig(2, 4, use_end2end=True),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    # because of the bad annoation, a wrong grad allreduce is inserted
+    assert _gencode_contains(tmp_path, RopeModel, 0, r'nnscaler.runtime.adapter.nn.identity_allreduce')
+    # def segment143(self, x_44, cos_45, sin_46, position_ids_47):
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 42, in forward,  bsz, seq_len, hidden_dim = x.shape
+    #     im_output_91 = builtins.getattr(x_44, 'shape')
+    #     getattr_1_41 = im_output_91[0]
+    #     getattr_1_42 = im_output_91[1]
+    #     getattr_1_43 = im_output_91[2]
+    #     del im_output_91
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 43, in forward,  q = self.q_proj(x)
+    #     linear_50 = torch.nn.functional.linear(x_44, self.q_proj_weight_49, bias=None)
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 44, in forward,  k = self.k_proj(x)
+    #     linear_1_52 = torch.nn.functional.linear(x_44, self.k_proj_weight_51, bias=None)
+    #     del x_44
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 45, in forward,  q = q.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     view_53 = torch.Tensor.view(linear_50, size=(getattr_1_41, getattr_1_42, 8, 64))
+    #     del linear_50
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 45, in forward,  q = q.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     transpose_54 = torch.transpose(view_53, dim0=1, dim1=2)
+    #     del view_53
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 46, in forward,  k = k.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     view_1_55 = torch.Tensor.view(linear_1_52, size=(getattr_1_41, getattr_1_42, 8, 64))
+    #     del linear_1_52
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 46, in forward,  k = k.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     transpose_1_56 = torch.transpose(view_1_55, dim0=1, dim1=2)
+    #     del view_1_55
+    #     transpose_54 = nnscaler.runtime.adapter.nn.identity_allreduce(transpose_54, ranks=[0, 1])
+    #     transpose_1_73 = nnscaler.runtime.adapter.nn.split_allgather(transpose_1_56, dim=1, ranks=[0, 1])
+    #     del transpose_1_56
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 47, in forward,  q, k = apply_rotary_pos_emb(q, k, cos, sin, position_ids)
+    #     apply_rotary_pos_emb_57, apply_rotary_pos_emb_75 = tests.autodist.spmd_solver.test_follow.apply_rotary_pos_emb(transpose_54, transpose_1_73, cos_45, sin_46, position_ids_47)
+    #     del cos_45, sin_46, position_ids_47, transpose_54, transpose_1_73
+    #     apply_rotary_pos_emb_58 = nnscaler.runtime.adapter.nn.allgather_split(apply_rotary_pos_emb_75, dim=1, ranks=[0, 1])
+    #     del apply_rotary_pos_emb_75
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 48, in forward,  out = q + k
+    #     add_59 = torch.add(apply_rotary_pos_emb_57, apply_rotary_pos_emb_58, alpha=1)
+    #     del apply_rotary_pos_emb_57, apply_rotary_pos_emb_58
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 49, in forward,  return out.sum()
+    #     sum_1_48 = torch.sum(add_59)
+    #     del add_59
+    #     return sum_1_48
+
+
+@replace_all_device_with('cpu')
+def test_rope_correct_anno(tmp_path):
+    from nnscaler.graph.parser.register import CustomizedOps
+    CustomizedOps.kOpMap.pop('tests.autodist.spmd_solver.test_follow.apply_rotary_pos_emb', None)
+
+    nnscaler.register_op('b h s^ d^ : /m, b m s^ d^ : /h, s^ d^, s^ d^, s^ -> b h s^ d^, b m s^ d^')(apply_rotary_pos_emb)
+
+    bsz, seq_len, head_num, hidden_dim = 2, 128, 8, 512
+    head_dim = hidden_dim // head_num
+    dummy_input = {
+        'x': torch.rand(bsz, seq_len, hidden_dim),
+        'cos': torch.rand(seq_len, head_dim),
+        'sin': torch.rand(seq_len, head_dim),
+        'position_ids': torch.arange(seq_len, dtype=torch.long),
+    }
+    m = RopeModel(head_num, hidden_dim)
+
+    m.train()
+    m_new = parallelize(
+        m,
+        dummy_input,
+        rope_m_policy,
+        ComputeConfig(2, 4, use_end2end=True),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    # grad allreduce will not be inserted because the annotation is fixed
+    assert not _gencode_contains(tmp_path, RopeModel, 0, r'nnscaler.runtime.adapter.nn.identity_allreduce')
+
+    # def segment137(self, x_44, cos_45, sin_46, position_ids_47):
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 42, in forward,  bsz, seq_len, hidden_dim = x.shape
+    #     im_output_89 = builtins.getattr(x_44, 'shape')
+    #     getattr_1_41 = im_output_89[0]
+    #     getattr_1_42 = im_output_89[1]
+    #     getattr_1_43 = im_output_89[2]
+    #     del im_output_89
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 43, in forward,  q = self.q_proj(x)
+    #     linear_50 = torch.nn.functional.linear(x_44, self.q_proj_weight_49, bias=None)
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 44, in forward,  k = self.k_proj(x)
+    #     linear_1_52 = torch.nn.functional.linear(x_44, self.k_proj_weight_51, bias=None)
+    #     del x_44
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 45, in forward,  q = q.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     view_53 = torch.Tensor.view(linear_50, size=(getattr_1_41, getattr_1_42, 8, 64))
+    #     del linear_50
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 45, in forward,  q = q.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     transpose_54 = torch.transpose(view_53, dim0=1, dim1=2)
+    #     del view_53
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 46, in forward,  k = k.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     view_1_55 = torch.Tensor.view(linear_1_52, size=(getattr_1_41, getattr_1_42, 8, 64))
+    #     del linear_1_52
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 46, in forward,  k = k.view(bsz, seq_len, self.head_num, self.head_dim).transpose(1, 2)
+    #     transpose_1_56 = torch.transpose(view_1_55, dim0=1, dim1=2)
+    #     del view_1_55
+    #     transpose_1_73 = nnscaler.runtime.adapter.nn.split_allgather(transpose_1_56, dim=1, ranks=[0, 1])
+    #     del transpose_1_56
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 47, in forward,  q, k = apply_rotary_pos_emb(q, k, cos, sin, position_ids)
+    #     apply_rotary_pos_emb_57, apply_rotary_pos_emb_75 = tests.autodist.spmd_solver.test_follow.apply_rotary_pos_emb(transpose_54, transpose_1_73, cos_45, sin_46, position_ids_47)
+    #     del cos_45, sin_46, position_ids_47, transpose_54, transpose_1_73
+    #     apply_rotary_pos_emb_58 = nnscaler.runtime.adapter.nn.allgather_split(apply_rotary_pos_emb_75, dim=1, ranks=[0, 1])
+    #     del apply_rotary_pos_emb_75
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 48, in forward,  out = q + k
+    #     add_59 = torch.add(apply_rotary_pos_emb_57, apply_rotary_pos_emb_58, alpha=1)
+    #     del apply_rotary_pos_emb_57, apply_rotary_pos_emb_58
+    #     # File "/data/weijiangxu/nnscaler/tests/autodist/spmd_solver/test_follow.py", line 49, in forward,  return out.sum()
+    #     sum_1_48 = torch.sum(add_59)
+    #     del add_59
+    #     return sum_1_48
+
+
+class ValuePartitionModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weights = torch.nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, input):
+        out = input @ self.weights
+        return out
+
+
+def value_partition_policy(graph, cfg):
+    from nnscaler.policies import OpPlan, OpPartition, get_pas_ops
+
+    for node in get_pas_ops(graph):
+        if node.fn == torch.matmul:
+            # split the `m` dimension
+            yield OpPlan(node, partition=OpPartition(input=0, dim=1))
+
+
+@replace_all_device_with('cpu')
+def test_value_partition_anno(tmp_path):
+    m = ValuePartitionModel()
+
+    m.train()
+    m_new = parallelize(
+        m,
+        {'input': torch.randn(4, 4)},
+        value_partition_policy,
+        ComputeConfig(2, 4, use_end2end=False),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    assert _gencode_contains(tmp_path, ValuePartitionModel, 0, r'nnscaler.runtime.adapter.nn.allreduce_identity')
+
+    # code looks like:
+    # def segment40(self, input_9):
+    #     input_15 = nnscaler.runtime.adapter.nn.split_allgather(input_9, dim=1, ranks=[0, 1])
+    #     del input_9
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode.py", line 2505, in forward,  out = input @ self.weights
+    #     matmul_19 = torch.matmul(input_15, self.weights_17)
+    #     del input_15
+    #     matmul_10 = nnscaler.runtime.adapter.nn.allreduce_identity(matmul_19, ranks=[0, 1])
+    #     del matmul_19
+    #     return matmul_10


### PR DESCRIPTION
This PR introduces a “no-grad-reduce” annotation mechanism for custom op shape annotations so that, for specific partition identifiers, nnscaler can skip inserting gradient all-reduce adapters (avoiding incorrect or redundant reductions).

This is done by extending ShapeAnno parsing to support : /<identifier> modifiers (and '/' as a shortcut) to control gradient-reduction behavior during partitioning.