### PR TITLE
feat: annotate partition_descs with fqn and op in saved plan

### DIFF
--- a/nnscaler/autodist/apis.py
+++ b/nnscaler/autodist/apis.py
@@ -113,40 +113,18 @@ def _write_plan_json(plan_json, f):
         {"cid": 11, "partition": [[[0, 0], 2]], "fqn": "...", "op": "..."}
     while the rest of the JSON uses standard indent=2 pretty-printing.
     """
+    plan_json = copy.deepcopy(plan_json)
+    markers = {}
+    for spmd in plan_json.get('desc', {}).get('spmd_descs', []):
+        for i, entry in enumerate(spmd.get('partition_descs', [])):
+            if isinstance(entry, dict) and 'cid' in entry:
+                marker = f'__COMPACT_{entry["cid"]}__'
+                markers[f'"{marker}"'] = json.dumps(entry, separators=(', ', ': '))
+                spmd['partition_descs'][i] = marker
     text = json.dumps(plan_json, indent=2)
-    # Post-process: collapse each partition_descs entry dict onto one line.
-    # These appear as multi-line dicts within the "partition_descs" array
-    # that contain a "cid" key. We match opening `{` with `"cid"` and
-    # collapse everything up to the matching `}`.
-    result = []
-    lines = text.split('\n')
-    i = 0
-    while i < len(lines):
-        stripped = lines[i].lstrip()
-        if stripped.startswith('{') and i + 1 < len(lines) and '"cid"' in lines[i + 1]:
-            # Collect lines until the closing brace at the same indent level
-            indent = len(lines[i]) - len(stripped)
-            brace_depth = 0
-            collected = []
-            j = i
-            while j < len(lines):
-                for ch in lines[j]:
-                    if ch == '{':
-                        brace_depth += 1
-                    elif ch == '}':
-                        brace_depth -= 1
-                collected.append(lines[j].strip())
-                if brace_depth == 0:
-                    break
-                j += 1
-            compact = ' '.join(collected)
-            # re-add proper indentation
-            result.append(' ' * indent + compact)
-            i = j + 1
-        else:
-            result.append(lines[i])
-            i += 1
-    f.write('\n'.join(result))
+    for marker, compact in markers.items():
+        text = text.replace(marker, compact)
+    f.write(text)
 
 
 def parallelize_graph(graph: IRGraph,

--- a/nnscaler/autodist/apis.py
+++ b/nnscaler/autodist/apis.py
@@ -1,29 +1,29 @@
 #  Copyright (c) Microsoft Corporation.
 #  Licensed under the MIT License.
 
-from .spmd_solver import calc_optimal_spmd_plan, analysis_pretty_printer
-from .pipeline_solver import calc_optimal_pp_plan
-from .autodist_config import AutoDistConfig
-from .model_graph import ModelGraph, estimate_mem_lower_bound
-from .descs import *
-from .util import replica, partition_node
+import copy
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
 
 from nnscaler.graph import IRGraph
-from nnscaler.graph.segment import IRSegment
-from nnscaler.ir.operator import IRDataOperation, IRFwOperation
-from nnscaler.ir.tensor import IRSubTensor
-from nnscaler.ir import IRCell
 from nnscaler.graph.function import IRDimops
 from nnscaler.graph.function.anchor import IRGraphAnchor
 from nnscaler.graph.function.pyfunc import IRPyFunc
 from nnscaler.graph.schedule.predefined import PredefinedSched
+from nnscaler.graph.segment import IRSegment
+from nnscaler.ir import IRCell
+from nnscaler.ir.operator import IRDataOperation, IRFwOperation
+from nnscaler.ir.tensor import IRSubTensor
 
-import json
-import logging
-import copy
-from typing import Dict, List
-from pathlib import Path
-from collections import defaultdict
+from .autodist_config import AutoDistConfig
+from .descs import *
+from .model_graph import ModelGraph, estimate_mem_lower_bound
+from .pipeline_solver import calc_optimal_pp_plan
+from .spmd_solver import analysis_pretty_printer, calc_optimal_spmd_plan
+from .util import partition_node, replica
 
 _logger = logging.getLogger(__name__)
 
@@ -106,6 +106,49 @@ def calc_parallel_plan(graph: IRGraph,
     return pp_out
 
 
+def _write_plan_json(plan_json, f):
+    """Write plan JSON with compact one-line partition_descs entries.
+
+    Each entry in partition_descs is rendered as a single line like:
+        {"cid": 11, "partition": [[[0, 0], 2]], "fqn": "...", "op": "..."}
+    while the rest of the JSON uses standard indent=2 pretty-printing.
+    """
+    text = json.dumps(plan_json, indent=2)
+    # Post-process: collapse each partition_descs entry dict onto one line.
+    # These appear as multi-line dicts within the "partition_descs" array
+    # that contain a "cid" key. We match opening `{` with `"cid"` and
+    # collapse everything up to the matching `}`.
+    result = []
+    lines = text.split('\n')
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].lstrip()
+        if stripped.startswith('{') and i + 1 < len(lines) and '"cid"' in lines[i + 1]:
+            # Collect lines until the closing brace at the same indent level
+            indent = len(lines[i]) - len(stripped)
+            brace_depth = 0
+            collected = []
+            j = i
+            while j < len(lines):
+                for ch in lines[j]:
+                    if ch == '{':
+                        brace_depth += 1
+                    elif ch == '}':
+                        brace_depth -= 1
+                collected.append(lines[j].strip())
+                if brace_depth == 0:
+                    break
+                j += 1
+            compact = ' '.join(collected)
+            # re-add proper indentation
+            result.append(' ' * indent + compact)
+            i = j + 1
+        else:
+            result.append(lines[i])
+            i += 1
+    f.write('\n'.join(result))
+
+
 def parallelize_graph(graph: IRGraph,
                       autodist_config: AutoDistConfig) -> IRGraph:
     segments: List[IRSegment] = graph.select(ntype=IRSegment)
@@ -122,8 +165,14 @@ def parallelize_graph(graph: IRGraph,
 
         if autodist_config.save_plan_path:
             _logger.info(f'save plan to {autodist_config.save_plan_path}')
+            # build cid-to-node mapping for annotating plan with fqn/op
+            cid2node_for_save: Dict[int, IRFwOperation] = {}
+            for node in graph.nodes():
+                if isinstance(node, IRFwOperation):
+                    cid2node_for_save[node.cid] = node
+            plan_json = search_out.to_json(cid2node=cid2node_for_save)
             with open(autodist_config.save_plan_path, 'w') as f:
-                json.dump(search_out.to_json(), f, indent=2)
+                _write_plan_json(plan_json, f)
 
     _logger.info(f'use plan with e2e time/s {1000 * search_out.e2e_time:.2f}ms')
     pp_desc = search_out.desc

--- a/nnscaler/autodist/apis.py
+++ b/nnscaler/autodist/apis.py
@@ -123,8 +123,9 @@ def _write_plan_json(plan_json, f):
                 markers[f'"{marker}"'] = json.dumps(entry, separators=(', ', ': '))
                 spmd['partition_descs'][i] = marker
     text = json.dumps(plan_json, indent=2)
-    pattern = re.compile('|'.join(re.escape(m) for m in markers))
-    text = pattern.sub(lambda match: markers[match.group(0)], text)
+    if markers:
+        pattern = re.compile('|'.join(re.escape(m) for m in markers))
+        text = pattern.sub(lambda match: markers[match.group(0)], text)
     f.write(text)
 
 

--- a/nnscaler/autodist/apis.py
+++ b/nnscaler/autodist/apis.py
@@ -4,6 +4,7 @@
 import copy
 import json
 import logging
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List
@@ -122,8 +123,8 @@ def _write_plan_json(plan_json, f):
                 markers[f'"{marker}"'] = json.dumps(entry, separators=(', ', ': '))
                 spmd['partition_descs'][i] = marker
     text = json.dumps(plan_json, indent=2)
-    for marker, compact in markers.items():
-        text = text.replace(marker, compact)
+    pattern = re.compile('|'.join(re.escape(m) for m in markers))
+    text = pattern.sub(lambda match: markers[match.group(0)], text)
     f.write(text)
 
 

--- a/nnscaler/autodist/descs.py
+++ b/nnscaler/autodist/descs.py
@@ -1,11 +1,9 @@
 #  Copyright (c) Microsoft Corporation.
 #  Licensed under the MIT License.
 
-from dataclasses import dataclass
-from typing import List, Dict, Tuple, Any, Optional
-import json
 import copy
-import yaml
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
 
 
 @dataclass
@@ -40,9 +38,19 @@ class TensorParallelDesc:
     mesh_desc: MeshDesc
     analysis: Dict[str, Any]
 
-    def to_json(self):
+    def to_json(self, cid2node=None):
         ret = {}
-        descs_list = [(k, v.desc) for k, v in self.partition_descs.items()]
+        if cid2node is not None:
+            descs_list = []
+            for k, v in self.partition_descs.items():
+                entry = {'cid': k, 'partition': v.desc}
+                node = cid2node.get(k)
+                if node is not None:
+                    entry['fqn'] = node.fqn
+                    entry['op'] = node.signature
+                descs_list.append(entry)
+        else:
+            descs_list = [(k, v.desc) for k, v in self.partition_descs.items()]
         ret['partition_descs'] = descs_list
         ret['recompute_groups'] = self.recompute_groups
         ret['mesh_desc'] = self.mesh_desc.to_json()
@@ -52,8 +60,14 @@ class TensorParallelDesc:
     @staticmethod
     def from_json(ret):
         partition_descs = {}
-        for k, v in ret['partition_descs']:
-            partition_descs[k] = NodePartitionDesc(v)
+        for item in ret['partition_descs']:
+            if isinstance(item, dict):
+                # new format: {"cid": ..., "partition": ..., "fqn": ..., "op": ...}
+                partition_descs[item['cid']] = NodePartitionDesc(item['partition'])
+            else:
+                # old format: [cid, desc]
+                k, v = item
+                partition_descs[k] = NodePartitionDesc(v)
         return TensorParallelDesc(partition_descs,
                                   copy.deepcopy(ret['recompute_groups']),
                                   MeshDesc.from_json(ret['mesh_desc']),
@@ -88,9 +102,9 @@ class PipelineParallelDesc:
     recompute_groups: List[List[int]]
     mesh_desc: MeshDesc
 
-    def to_json(self):
+    def to_json(self, cid2node=None):
         return {
-            'spmd_descs': [desc.to_json() for desc in self.spmd_descs],
+            'spmd_descs': [desc.to_json(cid2node=cid2node) for desc in self.spmd_descs],
             'recompute_groups': self.recompute_groups,
             'mesh_desc': self.mesh_desc.to_json(),
         }
@@ -113,9 +127,9 @@ class PipelineSearchOutput:
     stage_all_times: List[float]
     stage_comp_times: List[float]
 
-    def to_json(self):
+    def to_json(self, cid2node=None):
         return {
-            'desc': self.desc.to_json(),
+            'desc': self.desc.to_json(cid2node=cid2node),
             'e2e_time': self.e2e_time,
             'stage_mems': self.stage_mems,
             'stage_all_times': self.stage_all_times,

--- a/nnscaler/autodist/descs.py
+++ b/nnscaler/autodist/descs.py
@@ -3,10 +3,9 @@
 
 import copy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-if TYPE_CHECKING:
-    from nnscaler.ir.operator import IRFwOperation
+from nnscaler.ir.operator import IRFwOperation
 
 
 @dataclass
@@ -41,15 +40,16 @@ class TensorParallelDesc:
     mesh_desc: MeshDesc
     analysis: Dict[str, Any]
 
-    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
+    def to_json(self, cid2node: Optional[Dict[int, IRFwOperation]] = None):
         ret = {}
         descs_list = []
         for k, v in self.partition_descs.items():
             entry = {'cid': k, 'partition': v.desc}
-            node = cid2node.get(k)
-            if node is not None:
-                entry['fqn'] = node.fqn
-                entry['op'] = node.signature
+            if cid2node is not None:
+                node = cid2node.get(k)
+                if node is not None:
+                    entry['fqn'] = node.fqn
+                    entry['op'] = node.signature
             descs_list.append(entry)
         ret['partition_descs'] = descs_list
         ret['recompute_groups'] = self.recompute_groups
@@ -81,7 +81,7 @@ class SPMDSearchOutput:
     all_time: float
     comp_time: float
 
-    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
+    def to_json(self, cid2node: Optional[Dict[int, IRFwOperation]] = None):
         return {
             'desc': self.desc.to_json(cid2node),
             'memory': self.memory,
@@ -102,7 +102,7 @@ class PipelineParallelDesc:
     recompute_groups: List[List[int]]
     mesh_desc: MeshDesc
 
-    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
+    def to_json(self, cid2node: Optional[Dict[int, IRFwOperation]] = None):
         return {
             'spmd_descs': [desc.to_json(cid2node=cid2node) for desc in self.spmd_descs],
             'recompute_groups': self.recompute_groups,
@@ -127,7 +127,7 @@ class PipelineSearchOutput:
     stage_all_times: List[float]
     stage_comp_times: List[float]
 
-    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
+    def to_json(self, cid2node: Optional[Dict[int, IRFwOperation]] = None):
         return {
             'desc': self.desc.to_json(cid2node=cid2node),
             'e2e_time': self.e2e_time,

--- a/nnscaler/autodist/descs.py
+++ b/nnscaler/autodist/descs.py
@@ -3,7 +3,10 @@
 
 import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from nnscaler.ir.operator import IRFwOperation
 
 
 @dataclass
@@ -38,19 +41,16 @@ class TensorParallelDesc:
     mesh_desc: MeshDesc
     analysis: Dict[str, Any]
 
-    def to_json(self, cid2node=None):
+    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
         ret = {}
-        if cid2node is not None:
-            descs_list = []
-            for k, v in self.partition_descs.items():
-                entry = {'cid': k, 'partition': v.desc}
-                node = cid2node.get(k)
-                if node is not None:
-                    entry['fqn'] = node.fqn
-                    entry['op'] = node.signature
-                descs_list.append(entry)
-        else:
-            descs_list = [(k, v.desc) for k, v in self.partition_descs.items()]
+        descs_list = []
+        for k, v in self.partition_descs.items():
+            entry = {'cid': k, 'partition': v.desc}
+            node = cid2node.get(k)
+            if node is not None:
+                entry['fqn'] = node.fqn
+                entry['op'] = node.signature
+            descs_list.append(entry)
         ret['partition_descs'] = descs_list
         ret['recompute_groups'] = self.recompute_groups
         ret['mesh_desc'] = self.mesh_desc.to_json()
@@ -81,9 +81,9 @@ class SPMDSearchOutput:
     all_time: float
     comp_time: float
 
-    def to_json(self):
+    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
         return {
-            'desc': self.desc.to_json(),
+            'desc': self.desc.to_json(cid2node),
             'memory': self.memory,
             'all_time': self.all_time,
             'comp_time': self.comp_time,
@@ -102,7 +102,7 @@ class PipelineParallelDesc:
     recompute_groups: List[List[int]]
     mesh_desc: MeshDesc
 
-    def to_json(self, cid2node=None):
+    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
         return {
             'spmd_descs': [desc.to_json(cid2node=cid2node) for desc in self.spmd_descs],
             'recompute_groups': self.recompute_groups,
@@ -127,7 +127,7 @@ class PipelineSearchOutput:
     stage_all_times: List[float]
     stage_comp_times: List[float]
 
-    def to_json(self, cid2node=None):
+    def to_json(self, cid2node: 'Dict[int, IRFwOperation]'):
         return {
             'desc': self.desc.to_json(cid2node=cid2node),
             'e2e_time': self.e2e_time,

--- a/tests/autodist/spmd_solver/test_follow.py
+++ b/tests/autodist/spmd_solver/test_follow.py
@@ -298,7 +298,13 @@ def test_follow_attention():
         ]
 
         def helper(search_out):
-            return search_out[0][0].to_json()['desc']['partition_descs']
+            # `partition_descs` is now a list of dicts annotated with `cid`,
+            # `partition`, and (optionally) `fqn`/`op`. Project back to the
+            # (cid, partition) tuple that this test asserts against.
+            return [
+                (entry['cid'], entry['partition'])
+                for entry in search_out[0][0].to_json()['desc']['partition_descs']
+            ]
 
         dp_spmd_outs = spmd_solver.do_dp([(0, model_graph.op_num - 1)], 1)
         ilp_spmd_outs = spmd_solver.do_ilp([(0, model_graph.op_num - 1)], 1)
@@ -370,7 +376,13 @@ def test_solver_data_parallel():
         ]
 
         def helper(search_out):
-            return search_out[0][0].to_json()['desc']['partition_descs']
+            # `partition_descs` is now a list of dicts annotated with `cid`,
+            # `partition`, and (optionally) `fqn`/`op`. Project back to the
+            # (cid, partition) tuple that this test asserts against.
+            return [
+                (entry['cid'], entry['partition'])
+                for entry in search_out[0][0].to_json()['desc']['partition_descs']
+            ]
 
         dp_spmd_outs = spmd_solver.do_dp([(0, model_graph.op_num - 1)], 1)
         ilp_spmd_outs = spmd_solver.do_ilp([(0, model_graph.op_num - 1)], 1)


### PR DESCRIPTION
## Summary

Improve readability of the saved parallelization plan JSON by annotating each `partition_descs` entry with the operator's fully qualified module name (`fqn`) and operator signature (`op`), and rendering each entry as a compact single line.

## Motivation

The current plan format uses opaque integer `cid` values and deeply nested arrays (~16 lines per entry), making it nearly impossible for users to understand or manually edit a saved plan:

```json
[11, [[[0, 0], 2]]]
```

## Changes

Each `partition_descs` entry is now a compact, self-describing one-line dict:

```json
{"cid": 11, "partition": [[[0, 0], 2]], "fqn": "gpt.transformer.h.0.attn.c_attn", "op": "torch.nn.functional.linear"}
```

This reduces the plan file from ~7500 lines to ~3900 lines for a 12-layer nanoGPT model.

### `nnscaler/autodist/descs.py`
- `TensorParallelDesc.to_json()` accepts an optional `cid2node` mapping; when provided, entries include `fqn` and `op` annotations. Without it, the old `[cid, desc]` list format is produced (preserving existing internal callers).
- `TensorParallelDesc.from_json()` auto-detects both old (`[cid, desc]` list) and new (dict) formats.
- The `cid2node` parameter is threaded through `PipelineParallelDesc.to_json()` and `PipelineSearchOutput.to_json()`.

### `nnscaler/autodist/apis.py`
- `parallelize_graph()` builds the `cid2node` mapping before saving and passes it to `to_json()`.
- New `_write_plan_json()` helper post-processes the JSON output so each partition entry stays on a single line while the rest of the file remains pretty-printed with `indent=2`.

## Backward Compatibility

The plan loader detects the format automatically — old plans with `[cid, desc]` list entries continue to load without any changes. The `fqn` and `op` fields are write-only annotations and are ignored during loading.