### PR TITLE
[Feat] add max seqlen on flash attention 4 calling

### DIFF
--- a/nnscaler/customized_ops/ring_attention/core/zigzag_allgather_attn_varlen_implementation.py
+++ b/nnscaler/customized_ops/ring_attention/core/zigzag_allgather_attn_varlen_implementation.py
@@ -166,6 +166,8 @@ def _run_flash_attn_varlen(
             v,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
             softmax_scale=softmax_scale,
             causal=causal,
             window_size=cute_window_size,

--- a/nnscaler/customized_ops/ring_attention/ring_attn_varlen.py
+++ b/nnscaler/customized_ops/ring_attention/ring_attn_varlen.py
@@ -151,6 +151,8 @@ def wrap_ring_attn_varlen_func(
                 q, k, v,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
                 softmax_scale=softmax_scale,
                 causal=causal,
                 window_size=cute_window_size,

--- a/nnscaler/customized_ops/ring_attention/sliding_window_attn.py
+++ b/nnscaler/customized_ops/ring_attention/sliding_window_attn.py
@@ -64,6 +64,8 @@ def wrap_sliding_window_attn_func(
                 q, k, v,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
                 softmax_scale=softmax_scale,
                 causal=causal,
                 window_size=cute_window_size,

--- a/nnscaler/customized_ops/ring_attention/zigzag_allgather_attn_varlen.py
+++ b/nnscaler/customized_ops/ring_attention/zigzag_allgather_attn_varlen.py
@@ -54,6 +54,8 @@ def wrap_zigzag_allgather_attn_varlen_func(
                 q, k, v,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
                 softmax_scale=softmax_scale,
                 causal=causal,
                 window_size=cute_window_size,


### PR DESCRIPTION
Add ```max_seqlen_q``` and ```max_seqlen_k``` kwargs in flash attention cute calling, which helps inner kernel pre-processing.