### PR TITLE
[BugFix] Add multiref when grad-reduce/no-grad-reduce are mixed used

### DIFF
--- a/nnscaler/graph/parser/converter.py
+++ b/nnscaler/graph/parser/converter.py
@@ -103,7 +103,9 @@ def to_fx_graph(model: torch.nn.Module, dummy_input) -> torch.fx.GraphModule:
     cube_rt_funcs = [
         cube_rt_function.anchor,
         cube_rt_function.ifexpr,
-        cube_rt_function.fold_constant
+        cube_rt_function.fold_constant,
+        cube_rt_function.identity,
+        cube_rt_function.multiref,
     ]
     leaf_functions.update({
         func: LeafWrapInfo([Location(cube_rt_function, func.__name__)], True, None)

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -769,6 +769,11 @@ def fn(
         # The reason is that stages may have different number of devices, it is hard to synchronize gradients directly
         # by inserting reducers although weights are all REPLICAED.
 
+        # The effect is that the parameter will be converted to a normal tensor
+        # and will be passed to the next stages.
+        # So only the first stage will have the parameter as a parameter,
+        # and the later stages will have it as an activation tensor.
+
         # A further explanation:
         # 1. len(splits) > 1: the param is partitioned in different ways in its different consumers.
         #    this can also happen when pipeline parallelism is not used

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -490,6 +490,57 @@ def get_pas_ops(graph: IRGraph) -> List[IRFwOperation]:
     return graph.select(ntype=IRFwOperation)
 
 
+def _identity_segment_output(tensor: IRSubTensor, segment: IRSegment) -> IRFwOperation:
+    """
+    Insert an identity operator for the segment output tensor to make it easier to handle in policy.
+    After the insertion, the original output tensor will be replaced by the identity operator's output tensor in the graph.
+    The effect of this function is like:
+    Before:
+    ```
+    x = op1(...)
+    y = op2(x, ...)
+    return x, y
+    ```
+    After:
+    ```
+    x = op1(...)
+    y = op2(x, ...)
+    z = identity(x)
+    return z, y
+    ```
+    In other words, the segment output will never be inputs to any operators.
+
+    """
+    from nnscaler.graph.function.function import Identity
+
+    last_fwop_idx = -1
+    for idx, node in enumerate(segment._nodes):
+        if isinstance(node, IRFwOperation):
+            last_fwop_idx = idx
+    insert_idx = last_fwop_idx + 1
+
+    fwop = Identity(tensor)
+    output = tensor.parent.like().tosub()
+    fwop.set_output(0, output)
+    fwop.device = segment.device
+    if tensor.requires_grad:
+        # set input grad
+        igrad = tensor.parent.grad.select(tensor.indmap, tensor.valmap)
+        fwop.input(0).grad = igrad
+        # set output grad
+        otensor = fwop.output(0).parent
+        ograd = otensor.grad.select(tensor.indmap, (0,1))
+        fwop.output(0).grad = ograd
+        # insert identity
+        segment.finsert(fwop, insert_idx)
+    else:
+        segment.insert(fwop, insert_idx)
+
+    segment.replace_output(tensor, fwop.output(0))
+
+    return fwop
+
+
 def fn(
         graph: IRGraph, cfg: 'ComputeConfig',
         policy: Union[
@@ -804,6 +855,16 @@ def fn(
                 # TODO: is it possible to have TP here?
                 op_plans[node] = OpPlan(op=node, stage_id=stage_id, partition=None)
 
+    for stage_id, seg in enumerate(pp_segs):
+        for sub_tensor in IR.get_objects(seg.outputs()):
+            if not isinstance(sub_tensor, IRSubTensor):
+                continue
+            if seg.consumers(sub_tensor.parent):
+                ident_op = _identity_segment_output(sub_tensor, seg)
+                op_plans[ident_op] = OpPlan(op=ident_op, stage_id=stage_id, partition=None)
+                # 'rn' means `ident_op` is replicated and grad doesn't need to be all-reduced
+                tensor_splits[sub_tensor.parent].setdefault(stage_id, set()).add('rn')
+
     # add multiref to an activation tensor when the states of the tensor and its grad are different
     # among consumers and current segment's outputs
     for ftensor, stage_info in tensor_splits.items():
@@ -818,14 +879,12 @@ def fn(
                 stage.outputs(),
                 lambda x: isinstance(x, IRSubTensor) and x.parent == ftensor
             )
+            assert not is_seg_output[idx] or not stage.consumers(ftensor)
 
         for idx, splits in stage_info.items():
             stage = pp_segs[idx]
             split_list = list(splits)
-            if len(split_list) > 1 or (
-                # treat segment output as a consumer (replicated but not all-reduced)
-                is_seg_output[idx] and split_list[0] != 'rn'
-            ):
+            if len(split_list) > 1:
                 _logger.debug(f'add multiref for {ftensor} in stage {stage}')
                 stage.multiref(ftensor, comment='activation')
 

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -551,8 +551,16 @@ def fn(
     # key: IRFullTensor
     # value:
     #   key: stage_id
-    #   value: set of dims in this stage, None if the tensor is replicated in this stage
-    tensor_splits: dict[IRFullTensor, dict[int, set[Optional[int]]]] = {}
+    #   value: set of dims in this stage,
+    #       'rr' if the tensor is replicated and grad will be all-reduced:
+    #            One case where grad will be all-reduced:
+    #            1. op is partitioned on other tensors, and this tensor is not marked as '/'(no-grad-reduce)
+    #       'rn' if the tensor is replicated and grad will not be all-reduced.
+    #            Two cases where grad will not be all-reduced:
+    #            1. op is partitioned on other tensors, and this tensor is marked as '/'(no-grad-reduce)
+    #            2. op is replicated
+    #       int: the partitioned dim if the tensor is partitioned
+    tensor_splits: dict[IRFullTensor, dict[int, set[int | Literal['rr', 'rn']]]] = {}
     # store the last split info for each tensor to help handle auto partition
     # None: replicated
     # 'value': value partitioned
@@ -603,7 +611,7 @@ def fn(
 
         # final partition plan for the op
         # key: input idx, value: partitioned dim
-        op_partition_map: dict[int, int] = {}
+        op_partition_map: dict[int, int | Literal['rn', 'rr']] = {}
         if op_partitions:
             # we partition the op based on the first partition plan
             # and then check the rest partitions are satisfied or not
@@ -611,10 +619,11 @@ def fn(
             partitioned_nodes = op_plan.op.algorithm('dim')\
                 .instantiate(idx=op_first_partition.input, dim=op_first_partition.dim, num=ngpus)
             subnode = partitioned_nodes[0]  # first subnode carries all necessary partition info
+            assert isinstance(subnode, IRDimops), "Internal Error: partitioned node should be IRDimops"
 
             # collect input partition info
             # key: input idx, value: partitioned dim
-            result_partitions: dict[int, int] = {}
+            result_partitions: dict[int, int | Literal['rn', 'rr']] = {}
             for idx, input in enumerate(subnode.inputs()):
                 if not isinstance(input, IRSubTensor):
                     continue
@@ -622,6 +631,8 @@ def fn(
                 assert len(split_dims) <= 1, "Internal Error: multiple splitdims in one input"
                 if split_dims:
                     result_partitions[idx] = split_dims[0]
+                else:
+                    result_partitions[idx] = 'rn' if subnode.ignore_grad_reduce(input_idx=idx) else 'rr'
 
             # check the rest partitions
             # Note if we only have one partition plan, the check is skipped, we can always partition it
@@ -677,7 +688,10 @@ def fn(
             if ftensor not in tensor_splits:
                 tensor_splits[ftensor] = {}
             if idx not in op_partition_map:
-                tensor_splits[ftensor].setdefault(op_plan.stage_id, set()).add(None)
+                assert not op_partition_map, "Internal Error: if op_partition_map is not empty, all input should have partition info"
+                # if the op is not partitioned,
+                # all inputs should be replicated, and no grad accumulation is needed
+                tensor_splits[ftensor].setdefault(op_plan.stage_id, set()).add('rn')
             else:
                 tensor_splits[ftensor].setdefault(op_plan.stage_id, set()).add(op_partition_map[idx])
 
@@ -749,7 +763,7 @@ def fn(
         if not ftensor.is_param():
             continue
         splits = set(k for v in stage_info.values() for k in v)
-        find_replicated = None in splits
+        find_replicated = 'rr' in splits or 'rn' in splits
         splits = list(splits)
         # For safety, we will add multiref when detecting shared param are all replicated for pipeline parallelism.
         # The reason is that stages may have different number of devices, it is hard to synchronize gradients directly
@@ -804,7 +818,8 @@ def fn(
             stage = pp_segs[idx]
             split_list = list(splits)
             if len(split_list) > 1 or (
-                is_seg_output[idx] and split_list[0] is not None # treat segment output as a consumer
+                # treat segment output as a consumer (replicated but not all-reduced)
+                is_seg_output[idx] and split_list[0] != 'rn'
             ):
                 _logger.debug(f'add multiref for {ftensor} in stage {stage}')
                 stage.multiref(ftensor, comment='activation')

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -616,7 +616,7 @@ def test_loss_insert_identity(tmp_path):
     #     return getattr_2_17, sum_1_34
 
 
-from nnscaler.runtime.function import identity
+from nnscaler.runtime.function import identity, multiref
 
 class LossDataExplicitIdentityModel(torch.nn.Module):
     def __init__(self):
@@ -667,3 +667,62 @@ def test_loss_explicit_identity(tmp_path):
     #     getattr_2_19 = builtins.getattr(sum_1_23, 'data')
     #     del sum_1_23
     #     return identity_18, getattr_2_19
+
+
+class LossDataExplicitMultirefModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(10, 10)
+
+    def forward(self, x):
+        x = self.fc(x)
+        l = x.sum()
+        l1, l2 = multiref(l, times=2)
+        return l1, l2.data
+
+
+@replace_all_device_with('cpu')
+def test_loss_explicit_multiref(tmp_path):
+    """
+    Test that if the user explicitly inserts a multiref for the loss,
+    The gencode partitioning logic should still correctly insert the necessary adapters (e.g. allreduce_identity) to ensure the multiref outputs are correctly partitioned
+    """
+    m = LossDataExplicitMultirefModel()
+    m.train()
+
+    trace_data = torch.randn([2, 10], dtype=torch.float32)
+    parallelize(
+            m,
+            {'x': trace_data},
+            _loss_data_policy,
+            ComputeConfig(2, 2, use_end2end=False),
+            reuse='override',
+            gen_savedir=tmp_path,
+            load_module=False,
+    )
+    assert True
+    assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.function.multiref')) == 1
+    assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.adapter.nn.split_allgather')) == 1
+    assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.adapter.nn.allreduce_identity')) == 1
+    assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.adapter.all_reduce')) == 1
+    # code looks like:
+    # def segment86(self, x_23):
+    #     x_38 = nnscaler.runtime.adapter.nn.split_allgather(x_23, dim=0, ranks=[0, 1])
+    #     del x_23
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 678, in forward,  x = self.fc(x)
+    #     linear_40 = torch.nn.functional.linear(x_38, self.fc_weight_26, self.fc_bias_27)
+    #     del x_38
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 679, in forward,  l = x.sum()
+    #     sum_1_42 = torch.sum(linear_40)
+    #     del linear_40
+    #     # create at IRAdapterGener:autoref, comment before transformation: File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 680, in forward,  l1, l2 = multiref(l, times=2)
+    #     multiref_52, multiref_53 = nnscaler.runtime.function.multiref(sum_1_42, times=2)
+    #     del sum_1_42
+    #     multiref_30 = nnscaler.runtime.adapter.all_reduce(multiref_53, ranks=[0, 1])
+    #     del multiref_53
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 681, in forward,  return l1, l2.data
+    #     getattr_2_25 = builtins.getattr(multiref_30, 'data')
+    #     del multiref_30
+    #     multiref_24 = nnscaler.runtime.adapter.nn.allreduce_identity(multiref_52, ranks=[0, 1])
+    #     del multiref_52
+    #     return multiref_24, getattr_2_25

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -1,10 +1,11 @@
 import torch
+import pytest
 
 from nnscaler import parallelize, ComputeConfig
 import nnscaler
 
 from tests.autodist.spmd_solver.test_follow import apply_rotary_pos_emb, Model as RopeModel
-from tests.parallel_module.test_gencode import replace_all_device_with, _gencode_contains
+from tests.parallel_module.test_gencode import replace_all_device_with, _gencode_contains, print_gencode
 
 
 def rope_m_policy(graph, cfg):
@@ -200,3 +201,301 @@ def test_value_partition_anno(tmp_path):
     #     matmul_10 = nnscaler.runtime.adapter.nn.allreduce_identity(matmul_19, ranks=[0, 1])
     #     del matmul_19
     #     return matmul_10
+
+
+@nnscaler.register_op('a b : /, b c -> a c')
+def _shared_skip_op(x, w):
+    """Custom op that asks nnscaler to skip grad all-reduce on input 0."""
+    return x @ w
+
+
+class _SharedInputModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w0 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w1 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w2 = torch.nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, raw_x):
+        # The same `x` is consumed by two operators:
+        #   - `_shared_skip_op`: annotation declares input 0 = ': /'
+        #     so its grad-reduce should be skipped.
+        #   - `torch.matmul`: standard op, full grad-reduce expected.
+        x = torch.nn.functional.linear(raw_x, self.w0)
+        a = _shared_skip_op(x, self.w1)
+        b = torch.matmul(x, self.w2)
+        return (a + b).sum()
+
+
+def _shared_input_partition_policy(graph, cfg):
+    """Partition both consumers along weight-dim 1 (= identifier 'c'),
+    which causes `x` (replicated input) to need grad reduction on the
+    `torch.matmul` side. The `_shared_skip_op` side is annotated with `: /`,
+    so its grad reduction must be skipped — but this MUST NOT alter the
+    `torch.matmul` side's gradient bookkeeping.
+    """
+    from nnscaler.policies import OpPlan, OpPartition, get_pas_ops
+
+    for node in get_pas_ops(graph):
+        if node.fn == torch.matmul:
+            yield OpPlan(node, partition=OpPartition(input=1, dim=1))
+        elif node.fn == _shared_skip_op:
+            yield OpPlan(node, partition=OpPartition(input=1, dim=1))
+
+
+@replace_all_device_with('cpu')
+def test_shared_input_with_no_grad_reduce_consumer(tmp_path):
+    """Two consumers of an internal activation `x`:
+      * `_shared_skip_op` is annotated with `: /` -> grad-reduce skipped;
+      * `torch.matmul` is a standard op -> grad-reduce required.
+
+    Both are partitioned along weight-dim 1 (identifier `c`), so `x` is
+    replicated across both ranks for both consumers. After fix, parallelize
+    should succeed and emit at least one `identity_allreduce` on the matmul
+    side.
+    """
+    m = _SharedInputModel()
+    m.train()
+    parallelize(
+        m,
+        {'raw_x': torch.randn(4, 4)},
+        _shared_input_partition_policy,
+        ComputeConfig(2, 4, use_end2end=True),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    # expected exactly one identity_allreduce (on torch.matmul's x input)"
+    assert len(_gencode_contains(tmp_path, _SharedInputModel, 0, r'.*identity_allreduce.*')) == 1
+
+    # code looks like:
+    # def segment110(self, raw_x_20):
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 223, in forward,  x = torch.nn.functional.linear(raw_x, self.w0)
+    #     linear_23 = torch.nn.functional.linear(raw_x_20, self.w0_22, bias=None)
+    #     del raw_x_20
+    #     # create at IRAdapterGener:autoref, comment before transformation: activation
+    #     linear_52, linear_53 = nnscaler.runtime.function.multiref(linear_23, times=2)
+    #     del linear_23
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 224, in forward,  a = _shared_skip_op(x, self.w1)
+    #     _shared_skip_op_42 = tests.parallel_module.test_gencode_partition._shared_skip_op(linear_52, self.w1_40)
+    #     del linear_52
+    #     linear_53 = nnscaler.runtime.adapter.nn.identity_allreduce(linear_53, ranks=[0, 1])
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 225, in forward,  b = torch.matmul(x, self.w2)
+    #     matmul_46 = torch.matmul(linear_53, self.w2_44)
+    #     del linear_53
+    #     _shared_skip_op_25 = nnscaler.runtime.adapter.nn.allgather_split(_shared_skip_op_42, dim=1, ranks=[0, 1])
+    #     del _shared_skip_op_42
+    #     matmul_27 = nnscaler.runtime.adapter.nn.allgather_split(matmul_46, dim=1, ranks=[0, 1])
+    #     del matmul_46
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 226, in forward,  return (a + b).sum()
+    #     add_28 = torch.add(_shared_skip_op_25, matmul_27, alpha=1)
+    #     del _shared_skip_op_25, matmul_27
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 226, in forward,  return (a + b).sum()
+    #     sum_1_21 = torch.sum(add_28)
+    #     del add_28
+    #     return sum_1_21
+
+
+class _SharedInputModelReplicatedGradReduce(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w0 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w1 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w2 = torch.nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, raw_x):
+        # The same `x` is consumed by two operators:
+        #   - `+`: replicated (and no grad reduce).
+        #   - `torch.matmul`: standard op, full grad-reduce expected.
+        x = torch.nn.functional.linear(raw_x, self.w0)
+        a = x + self.w1
+        b = torch.matmul(x, self.w2)
+        return (a + b).sum()
+
+
+@replace_all_device_with('cpu')
+def test_shared_input_replicated_grad_reduce(tmp_path):
+    """Two consumers of an internal activation `x`:
+      * `+` replicated (and no grad reduce);
+      * `torch.matmul` is a standard op -> grad-reduce required.
+    """
+    m = _SharedInputModelReplicatedGradReduce()
+    m.train()
+    parallelize(
+        m,
+        {'raw_x': torch.randn(4, 4)},
+        _shared_input_partition_policy,
+        ComputeConfig(2, 4, use_end2end=True),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    # expected exactly one identity_allreduce (on torch.matmul's x input)"
+    assert len(_gencode_contains(tmp_path, _SharedInputModelReplicatedGradReduce, 0, r'.*identity_allreduce.*')) == 1
+    # code looks like:
+    # def segment98(self, raw_x_20):
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 309, in forward,  x = torch.nn.functional.linear(raw_x, self.w0)
+    #     linear_23 = torch.nn.functional.linear(raw_x_20, self.w0_22, bias=None)
+    #     del raw_x_20
+    #     # create at IRAdapterGener:autoref, comment before transformation: activation
+    #     linear_48, linear_49 = nnscaler.runtime.function.multiref(linear_23, times=2)
+    #     del linear_23
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 310, in forward,  a = x + self.w1
+    #     add_25 = torch.add(linear_48, self.w1_24, alpha=1)
+    #     del linear_48
+    #     linear_49 = nnscaler.runtime.adapter.nn.identity_allreduce(linear_49, ranks=[0, 1])
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 311, in forward,  b = torch.matmul(x, self.w2)
+    #     matmul_42 = torch.matmul(linear_49, self.w2_40)
+    #     del linear_49
+    #     matmul_27 = nnscaler.runtime.adapter.nn.allgather_split(matmul_42, dim=1, ranks=[0, 1])
+    #     del matmul_42
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 312, in forward,  return (a + b).sum()
+    #     add_1_28 = torch.add(add_25, matmul_27, alpha=1)
+    #     del add_25, matmul_27
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 312, in forward,  return (a + b).sum()
+    #     sum_1_21 = torch.sum(add_1_28)
+    #     del add_1_28
+    #     return sum_1_21
+
+
+class _SharedInputModelReplicatedNoGradReduce(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w0 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w1 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w2 = torch.nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, raw_x):
+        # The same `x` is consumed by two operators:
+        #   - `+`: replicated (and no grad reduce).
+        #   - `_shared_skip_op`: replicated and no grad reduce.
+        x = torch.nn.functional.linear(raw_x, self.w0)
+        a = x + self.w1
+        b = _shared_skip_op(x, self.w2)
+        return (a + b).sum()
+
+
+@replace_all_device_with('cpu')
+def test_shared_input_replicated_no_grad_reduce(tmp_path):
+    """Two consumers of an internal activation `x`:
+      * `+` replicated (and no grad reduce);
+      * `_shared_skip_op` is a standard op -> grad-reduce required.
+    """
+    m = _SharedInputModelReplicatedNoGradReduce()
+    m.train()
+    parallelize(
+        m,
+        {'raw_x': torch.randn(4, 4)},
+        _shared_input_partition_policy,
+        ComputeConfig(2, 4, use_end2end=True),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    # expected no identity_allreduce (still have multiref added by `local_consumer_multiref` )
+    assert not _gencode_contains(tmp_path, _SharedInputModelReplicatedNoGradReduce, 0, r'.*identity_allreduce.*')
+    # code looks like:
+    # def segment74(self, raw_x_20):
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 371, in forward,  x = torch.nn.functional.linear(raw_x, self.w0)
+    #     linear_23 = torch.nn.functional.linear(raw_x_20, self.w0_22, bias=None)
+    #     del raw_x_20
+    #     # created at IRAdapterGener:local_consumer_multiref
+    #     linear_50, linear_54 = nnscaler.runtime.function.multiref(linear_23, times=2)
+    #     del linear_23
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 372, in forward,  a = x + self.w1
+    #     add_25 = torch.add(linear_50, self.w1_24, alpha=1)
+    #     del linear_50
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 373, in forward,  b = _shared_skip_op(x, self.w2)
+    #     _shared_skip_op_42 = tests.parallel_module.test_gencode_partition._shared_skip_op(linear_54, self.w2_40)
+    #     del linear_54
+    #     _shared_skip_op_27 = nnscaler.runtime.adapter.nn.allgather_split(_shared_skip_op_42, dim=1, ranks=[0, 1])
+    #     del _shared_skip_op_42
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 374, in forward,  return (a + b).sum()
+    #     add_1_28 = torch.add(add_25, _shared_skip_op_27, alpha=1)
+    #     del add_25, _shared_skip_op_27
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 374, in forward,  return (a + b).sum()
+    #     sum_1_21 = torch.sum(add_1_28)
+    #     del add_1_28
+    #     return sum_1_21
+
+
+class StageOutputModel(torch.nn.Module):
+    def __init__(self, no_grad_reduce=False):
+        hidden_dim = 4
+        self.no_grad_reduce = no_grad_reduce
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.randn(hidden_dim, hidden_dim))
+
+    def forward(self, x):
+        y = torch.nn.functional.relu(x)
+        if self.no_grad_reduce:
+            z = _shared_skip_op(y, self.w)
+        else:
+            z = torch.matmul(y, self.w)
+        w = y + z
+        return w.sum()
+
+
+def _stage_output_policy(graph, cfg):
+    from nnscaler.policies import OpPlan, get_pas_ops, OpPartition
+
+    matmul_found = False
+    for node in get_pas_ops(graph):
+        if matmul_found:
+            yield OpPlan(node,stage_id=1)
+        else:
+            if node.fn == torch.matmul or node.fn == _shared_skip_op:
+                yield OpPlan(node, stage_id=0, partition=OpPartition(input=1, dim=1))
+                matmul_found = True
+            else:
+                yield OpPlan(node, stage_id=0)
+
+
+@replace_all_device_with('cpu')
+@pytest.mark.parametrize('no_grad_reduce', [False, True])
+def test_stage_output(tmp_path, no_grad_reduce):
+    m = StageOutputModel(no_grad_reduce)
+    m.train()
+    parallelize(
+        m,
+        {'x': torch.randn(4, 4)},
+        _stage_output_policy,
+        ComputeConfig(4, 4, use_end2end=True,
+            pas_config={
+                'pipeline_nmicros': 2,
+                'pipeline_size': 2,
+            }
+        ),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    if no_grad_reduce:
+        assert not _gencode_contains(tmp_path, StageOutputModel, 0, r'nnscaler.runtime.function.multiref')
+        # code looks like:
+        # !!rank0
+        # def segment17(self, x_13):
+        #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 429, in forward,  y = torch.nn.functional.relu(x)
+        #     relu_15 = torch.nn.functional.relu(x_13, inplace=False)
+        #     del x_13
+        #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 431, in forward,  z = _shared_skip_op(y, self.w)
+        #     _shared_skip_op_40 = tests.parallel_module.test_gencode_partition._shared_skip_op(relu_15, self.w_38)
+        #     _shared_skip_op_17 = nnscaler.runtime.adapter.nn.allgather_split(_shared_skip_op_40, dim=1, ranks=[0, 1])
+        #     del _shared_skip_op_40
+        #     return relu_15, _shared_skip_op_17
+    else:
+        assert _gencode_contains(tmp_path, StageOutputModel, 0, r'nnscaler.runtime.function.multiref')
+        # code looks like:
+        # !!rank0
+        # def segment17(self, x_13):
+        #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 430, in forward,  y = torch.nn.functional.relu(x)
+        #     relu_15 = torch.nn.functional.relu(x_13, inplace=False)
+        #     del x_13
+        #     # create at IRAdapterGener:autoref, comment before transformation: activation
+        #     relu_39 = nnscaler.runtime.function.multiref(relu_15, times=1)
+        #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 434, in forward,  z = torch.matmul(y, self.w)
+        #     matmul_42 = torch.matmul(relu_39, self.w_40)
+        #     del relu_39
+        #     matmul_17 = nnscaler.runtime.adapter.nn.allgather_split(matmul_42, dim=1, ranks=[0, 1])
+        #     del matmul_42
+        #     return relu_15, matmul_17

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -554,3 +554,116 @@ def test_pp_shared_model(tmp_path):
             assert _gencode_contains(tmp_path, PPSharedModel, rank, r'self.register_parameter\(')
         else:
             assert not _gencode_contains(tmp_path, PPSharedModel, rank, r'self.register_parameter\(')
+
+
+class LossDataModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(10, 10)
+
+    def forward(self, x):
+        x = self.fc(x)
+        l = x.sum()
+        return l, l.data
+
+
+def _loss_data_policy(graph, cfg):
+    from nnscaler.policies import OpPlan, get_pas_ops, OpPartition
+
+    for node in get_pas_ops(graph):
+        if node.fn == torch.nn.functional.linear:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0))
+        if node.fn == torch.sum:
+            yield OpPlan(node, partition=OpPartition(input=0, dim=0))
+
+
+@replace_all_device_with('cpu')
+def test_loss_insert_identity(tmp_path):
+    m = LossDataModel()
+    m.train()
+
+    trace_data = torch.randn([2, 10], dtype=torch.float32)
+    parallelize(
+            m,
+            {'x': trace_data},
+            _loss_data_policy,
+            ComputeConfig(2, 2, use_end2end=False),
+            reuse='override',
+            gen_savedir=tmp_path,
+            load_module=False,
+    )
+
+    assert _gencode_contains(tmp_path, LossDataModel, 0, 'nnscaler.runtime.function.identity')
+    # nnscaler.runtime.adapter.nn.split_allgather
+    # and nnscaler.runtime.adapter.nn.allreduce_identity
+    assert len(_gencode_contains(tmp_path, LossDataModel, 0, 'nnscaler.runtime.adapter.nn.')) == 2
+    # code looks like:
+    # def segment73(self, x_15):
+    #     x_26 = nnscaler.runtime.adapter.nn.split_allgather(x_15, dim=0, ranks=[0, 1])
+    #     del x_15
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 565, in forward,  x = self.fc(x)
+    #     linear_28 = torch.nn.functional.linear(x_26, self.fc_weight_18, self.fc_bias_19)
+    #     del x_26
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 566, in forward,  l = x.sum()
+    #     sum_1_30 = torch.sum(linear_28)
+    #     del linear_28
+    #     sum_1_16 = nnscaler.runtime.adapter.nn.allreduce_identity(sum_1_30, ranks=[0, 1])
+    #     del sum_1_30
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 568, in forward,  return l, l.data
+    #     getattr_2_17 = builtins.getattr(sum_1_16, 'data')
+    #     sum_1_34 = nnscaler.runtime.function.identity(sum_1_16)
+    #     del sum_1_16
+    #     return getattr_2_17, sum_1_34
+
+
+from nnscaler.runtime.function import identity
+
+class LossDataExplicitIdentityModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(10, 10)
+
+    def forward(self, x):
+        x = self.fc(x)
+        l = x.sum()
+        z = identity(l)
+        return z, l.data
+
+
+@replace_all_device_with('cpu')
+def test_loss_explicit_identity(tmp_path):
+    m = LossDataExplicitIdentityModel()
+    m.train()
+
+    trace_data = torch.randn([2, 10], dtype=torch.float32)
+    parallelize(
+            m,
+            {'x': trace_data},
+            _loss_data_policy,
+            ComputeConfig(2, 2, use_end2end=False),
+            reuse='override',
+            gen_savedir=tmp_path,
+            load_module=False,
+    )
+    assert _gencode_contains(tmp_path, LossDataExplicitIdentityModel, 0, 'nnscaler.runtime.function.identity')
+    # nnscaler.runtime.adapter.nn.split_allgather
+    # and nnscaler.runtime.adapter.nn.allreduce_identity
+    assert len(_gencode_contains(tmp_path, LossDataExplicitIdentityModel, 0, 'nnscaler.runtime.adapter.nn.')) == 2
+    # code looks like:
+    # def segment73(self, x_17):
+    #     x_30 = nnscaler.runtime.adapter.nn.split_allgather(x_17, dim=0, ranks=[0, 1])
+    #     del x_17
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 627, in forward,  x = self.fc(x)
+    #     linear_32 = torch.nn.functional.linear(x_30, self.fc_weight_20, self.fc_bias_21)
+    #     del x_30
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 628, in forward,  l = x.sum()
+    #     sum_1_34 = torch.sum(linear_32)
+    #     del linear_32
+    #     sum_1_23 = nnscaler.runtime.adapter.nn.allreduce_identity(sum_1_34, ranks=[0, 1])
+    #     del sum_1_34
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 629, in forward,  z = identity(l)
+    #     identity_18 = nnscaler.runtime.function.identity(sum_1_23)
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 630, in forward,  return z, l.data
+    #     getattr_2_19 = builtins.getattr(sum_1_23, 'data')
+    #     del sum_1_23
+    #     return identity_18, getattr_2_19

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -419,6 +419,83 @@ def test_shared_input_replicated_no_grad_reduce(tmp_path):
     #     return sum_1_21
 
 
+class MultileRRModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w0 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w1 = torch.nn.Parameter(torch.randn(4, 4))
+        self.w2 = torch.nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, input):
+        x = torch.nn.functional.linear(input, self.w0)
+        y = torch.nn.functional.linear(input, self.w1)
+        z = torch.nn.functional.linear(input, self.w2)
+        a = torch.matmul(x, y)
+        b = torch.matmul(x, z)
+        return (a + b).sum()
+
+
+def multirr_pas(graph, cfg):
+    from nnscaler.policies import OpPlan, OpPartition, get_pas_ops
+
+    for node in get_pas_ops(graph):
+        if node.fn == torch.matmul:
+            yield OpPlan(node, partition=OpPartition(input=1, dim=1))
+
+
+@replace_all_device_with('cpu')
+def test_multiref_multi_rr(tmp_path):
+    """
+    Test the case of two RR (replicate + allreduce) pattern
+    """
+    m = MultileRRModule()
+    m.train()
+    parallelize(
+        m,
+        {'input': torch.randn(4, 4)},
+        multirr_pas,
+        ComputeConfig(2, 4, use_end2end=True),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    assert True
+    # code looks like (no multiref are generated in `fn`):
+    # def segment124(self, input_24):
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 430, in forward,  x = torch.nn.functional.linear(input, self.w0)
+    #     linear_27 = torch.nn.functional.linear(input_24, self.w0_26, bias=None)
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 431, in forward,  y = torch.nn.functional.linear(input, self.w1)
+    #     linear_1_29 = torch.nn.functional.linear(input_24, self.w1_28, bias=None)
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 432, in forward,  z = torch.nn.functional.linear(input, self.w2)
+    #     linear_2_31 = torch.nn.functional.linear(input_24, self.w2_30, bias=None)
+    #     del input_24
+    #     linear_27 = nnscaler.runtime.adapter.nn.identity_allreduce(linear_27, ranks=[0, 1])
+    #     # created at IRAdapterGener:local_consumer_multiref
+    #     linear_70, linear_74 = nnscaler.runtime.function.multiref(linear_27, times=2)
+    #     del linear_27
+    #     linear_1_48 = nnscaler.runtime.adapter.nn.split_allgather(linear_1_29, dim=1, ranks=[0, 1])
+    #     del linear_1_29
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 433, in forward,  a = torch.matmul(x, y)
+    #     matmul_50 = torch.matmul(linear_70, linear_1_48)
+    #     del linear_70, linear_1_48
+    #     linear_2_52 = nnscaler.runtime.adapter.nn.split_allgather(linear_2_31, dim=1, ranks=[0, 1])
+    #     del linear_2_31
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 434, in forward,  b = torch.matmul(x, z)
+    #     matmul_1_54 = torch.matmul(linear_74, linear_2_52)
+    #     del linear_74, linear_2_52
+    #     matmul_32 = nnscaler.runtime.adapter.nn.allgather_split(matmul_50, dim=1, ranks=[0, 1])
+    #     del matmul_50
+    #     matmul_1_33 = nnscaler.runtime.adapter.nn.allgather_split(matmul_1_54, dim=1, ranks=[0, 1])
+    #     del matmul_1_54
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 435, in forward,  return (a + b).sum()
+    #     add_34 = torch.add(matmul_32, matmul_1_33, alpha=1)
+    #     del matmul_32, matmul_1_33
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 435, in forward,  return (a + b).sum()
+    #     sum_1_25 = torch.sum(add_34)
+    #     del add_34
+    #     return sum_1_25
+
+
 class StageOutputModel(torch.nn.Module):
     def __init__(self, no_grad_reduce=False):
         hidden_dim = 4

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -459,8 +459,9 @@ def test_multiref_multi_rr(tmp_path):
         load_module=False,
         reuse='override',
     )
-    assert True
-    # code looks like (no multiref are generated in `fn`):
+    # no multiref are generated in `fn`
+    assert not _gencode_contains(tmp_path, MultileRRModule, 0, r'activation')
+    # code looks like:
     # def segment124(self, input_24):
     #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_partition.py", line 430, in forward,  x = torch.nn.functional.linear(input, self.w0)
     #     linear_27 = torch.nn.functional.linear(input_24, self.w0_26, bias=None)
@@ -777,7 +778,6 @@ def test_loss_explicit_multiref(tmp_path):
             gen_savedir=tmp_path,
             load_module=False,
     )
-    assert True
     assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.function.multiref')) == 1
     assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.adapter.nn.split_allgather')) == 1
     assert len(_gencode_contains(tmp_path, LossDataExplicitMultirefModel, 0, 'nnscaler.runtime.adapter.nn.allreduce_identity')) == 1

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -251,7 +251,7 @@ def test_shared_input_with_no_grad_reduce_consumer(tmp_path):
 
     Both are partitioned along weight-dim 1 (identifier `c`), so `x` is
     replicated across both ranks for both consumers. After fix, parallelize
-    should succeed and emit at least one `identity_allreduce` on the matmul
+    should succeed and emit one `identity_allreduce` on the matmul
     side.
     """
     m = _SharedInputModel()
@@ -265,7 +265,7 @@ def test_shared_input_with_no_grad_reduce_consumer(tmp_path):
         load_module=False,
         reuse='override',
     )
-    # expected exactly one identity_allreduce (on torch.matmul's x input)"
+    # expected exactly one identity_allreduce (on torch.matmul's x input)
     assert len(_gencode_contains(tmp_path, _SharedInputModel, 0, r'.*identity_allreduce.*')) == 1
 
     # code looks like:
@@ -330,7 +330,7 @@ def test_shared_input_replicated_grad_reduce(tmp_path):
         load_module=False,
         reuse='override',
     )
-    # expected exactly one identity_allreduce (on torch.matmul's x input)"
+    # expected exactly one identity_allreduce (on torch.matmul's x input)
     assert len(_gencode_contains(tmp_path, _SharedInputModelReplicatedGradReduce, 0, r'.*identity_allreduce.*')) == 1
     # code looks like:
     # def segment98(self, raw_x_20):
@@ -379,7 +379,7 @@ class _SharedInputModelReplicatedNoGradReduce(torch.nn.Module):
 def test_shared_input_replicated_no_grad_reduce(tmp_path):
     """Two consumers of an internal activation `x`:
       * `+` replicated (and no grad reduce);
-      * `_shared_skip_op` is a standard op -> grad-reduce required.
+      * `_shared_skip_op` replicated and no grad reduce.
     """
     m = _SharedInputModelReplicatedNoGradReduce()
     m.train()

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -499,3 +499,58 @@ def test_stage_output(tmp_path, no_grad_reduce):
         #     matmul_17 = nnscaler.runtime.adapter.nn.allgather_split(matmul_42, dim=1, ranks=[0, 1])
         #     del matmul_42
         #     return relu_15, matmul_17
+
+
+def _pp_shared_policy(graph, cfg):
+    from nnscaler.policies import OpPlan, get_pas_ops, OpPartition
+
+    relu_found = False
+    for node in get_pas_ops(graph):
+        if relu_found:
+            yield OpPlan(node,stage_id=1)
+        else:
+            if node.fn == torch.nn.functional.relu:
+                yield OpPlan(node, stage_id=0, partition=OpPartition(input=1, dim=1))
+                relu_found = True
+            else:
+                yield OpPlan(node, stage_id=0)
+
+
+class PPSharedModel(torch.nn.Module):
+    def __init__(self, hidden_dim):
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.randn(hidden_dim, hidden_dim))
+
+    def forward(self, x):
+        x = torch.matmul(x, self.w)
+        x = torch.nn.functional.relu(x)
+        x = torch.matmul(x, self.w)
+        return x.sum()
+
+
+@replace_all_device_with('cpu')
+def test_pp_shared_model(tmp_path):
+    m = PPSharedModel(4)
+    m.train()
+    parallelize(
+        m,
+        {'x': torch.randn(4, 4)},
+        _pp_shared_policy,
+        ComputeConfig(2, 4, use_end2end=True,
+            pas_config={
+                'pipeline_nmicros': 2,
+                'pipeline_size': 2,
+            }
+        ),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    # only the first stage (rank 0/2) should have the shared parameter,
+    # and only it should register it as a parameter
+    # (the other stage gets it as a non-parameter shared input)
+    for rank in range(4):
+        if rank % 2 == 0:
+            assert _gencode_contains(tmp_path, PPSharedModel, rank, r'self.register_parameter\(')
+        else:
+            assert not _gencode_contains(tmp_path, PPSharedModel, rank, r'self.register_parameter\(')


### PR DESCRIPTION
This pull request improves the handling of replicated tensors and gradient reduction logic in `fn` policy. It introduces a more precise distinction between replicated tensors that require gradient all-reduce and those that do not, so we can add `multiref` more precisely.
