### PR TITLE
[Hotfix] wrongly mixed group rank with global rank in broadcast_mixed_data

### DIFF
--- a/nnscaler/utils.py
+++ b/nnscaler/utils.py
@@ -885,7 +885,8 @@ def broadcast_mixed_data(
     Args:
         data (Optional[dict]): The data to be broadcasted.
             for non-src ranks, this must be None.
-        src_rank (int): The source rank to broadcast from. Default: 0.
+        src_rank (int): The source global rank to broadcast from. Default: 0.
+            Source rank is based on global process group (regardless of ``group`` argument)
         group (torch.distributed.ProcessGroup, optional): The process group to use for broadcasting.
             If None, the default process group will be used. Default: None.
         device (str or torch.device, optional): The device to use for receiving tensors on non-src ranks.
@@ -900,7 +901,8 @@ def broadcast_mixed_data(
     if isinstance(device, str):
         # need to compare device later, so convert to torch.device
         device = torch.device(device)
-    rank = torch.distributed.get_rank(group=group)
+
+    rank = torch.distributed.get_rank()
 
     # share the structure and tensor shapes
     if rank == src_rank:

--- a/nnscaler/utils.py
+++ b/nnscaler/utils.py
@@ -880,7 +880,8 @@ def broadcast_mixed_data(
     device: Optional[Union[str, torch.device]] = None,
 ):
     """
-    Broadcast the data (containing tensors) from src_rank to all other ranks.
+    Broadcast the data (containing tensors) from `src_rank` to the ranks in `group`
+    (`src_rank` is based on the global process group, and should be a member of `group`).
 
     Args:
         data (Optional[dict]): The data to be broadcasted.


### PR DESCRIPTION
This pull request updates the `broadcast_mixed_data` function in `nnscaler/utils.py` to clarify and correct how the source rank and current rank are determined during distributed data broadcasting. The main focus is on ensuring the source rank is always interpreted in the context of the global process group, regardless of any custom group passed to the function.

Clarification and correction of rank handling:

* The docstring for the `src_rank` argument is updated to specify that it refers to the global rank, not the rank within any custom process group, and that the source rank is always based on the global process group.
* The function now always retrieves the global rank using `torch.distributed.get_rank()` without a group argument, ensuring consistent behavior regardless of the `group` parameter.