### PR TITLE
[Refine] Specify device_id in init_process_group

### DIFF
--- a/nnscaler/runtime/device.py
+++ b/nnscaler/runtime/device.py
@@ -30,7 +30,8 @@ class _DeviceGroup:
         else:
             if not torch.distributed.is_initialized():
                 torch.distributed.init_process_group(
-                    backend='nccl', timeout=_LARGE_TIMEOUT
+                    backend='nccl', timeout=_LARGE_TIMEOUT,
+                    device_id=torch.device('cuda', int(os.environ.get('LOCAL_RANK'))),
                 )
                 self._is_pg_initer = True
 

--- a/nnscaler/runtime/device.py
+++ b/nnscaler/runtime/device.py
@@ -29,10 +29,15 @@ class _DeviceGroup:
             self.node_rank = 0
         else:
             if not torch.distributed.is_initialized():
-                torch.distributed.init_process_group(
-                    backend='nccl', timeout=_LARGE_TIMEOUT,
-                    device_id=torch.device('cuda', int(os.environ.get('LOCAL_RANK'))),
-                )
+                if torch.__version__ >= (2, 3):
+                    torch.distributed.init_process_group(
+                        backend='nccl', timeout=_LARGE_TIMEOUT,
+                        device_id=int(os.environ.get('LOCAL_RANK')),
+                    )
+                else:
+                    torch.distributed.init_process_group(
+                        backend='nccl', timeout=_LARGE_TIMEOUT,
+                    )
                 self._is_pg_initer = True
 
             # disable it for now due to connection refused error when nnodes > 1

--- a/tests/parallel_module/test_gencode_kwargs.py
+++ b/tests/parallel_module/test_gencode_kwargs.py
@@ -187,3 +187,44 @@ def test_dictargs(tmp_path):
     # def _forward_impl(self, x, kwargs):
     #     add_3_36 = self.segment52(x, kwargs)
     #     return add_3_36
+
+
+@nnscaler.register_op('*, * -> *', name='kw_implicit_operator')
+def kw_implicit_operator(x: torch.Tensor, y: torch.Tensor, a, b ,c) -> torch.Tensor:
+    return x + y
+
+
+class ImplicitKwModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, x):
+        # even 3/4/5 are passed as args, not kwargs,
+        # in generate code we still treat them as kwargs
+        # and pass them to operator
+        # because they are not listed in the annotation of the operator
+        return kw_implicit_operator(x, self.scale, 3, 4, 5)
+
+
+@replace_all_device_with('cpu')
+def test_implicit_kw_args(tmp_path):
+    m = ImplicitKwModule()
+    m.train()
+    parallelize(
+        m,
+        {'x': torch.randn(4, 4)},
+        'dp',
+        ComputeConfig(1, 1, constant_folding=False),
+        gen_savedir=tmp_path,
+        load_module=False,
+        reuse='override',
+    )
+    assert _gencode_contains(tmp_path, ImplicitKwModule, 0,
+        r'tests.parallel_module.test_gencode_kwargs.kw_implicit_operator\(x_\d+, self.scale_\d+, a=3, b=4, c=5\)')
+    # code looks like:
+    # def segment14(self, x_9):
+    #     # File "/data/weijiangxu/nnscaler/tests/parallel_module/test_gencode_kwargs.py", line 203, in forward,  return kw_implicit_operator(x, self.scale, 3, 4, 5)
+    #     kw_implicit_operator_10 = tests.parallel_module.test_gencode_kwargs.kw_implicit_operator(x_9, self.scale_11, a=3, b=4, c=5)
+    #     del x_9
+    #     return kw_implicit_operator_10

--- a/tests/parallel_module/test_gencode_kwargs.py
+++ b/tests/parallel_module/test_gencode_kwargs.py
@@ -190,7 +190,7 @@ def test_dictargs(tmp_path):
 
 
 @nnscaler.register_op('*, * -> *', name='kw_implicit_operator')
-def kw_implicit_operator(x: torch.Tensor, y: torch.Tensor, a, b ,c) -> torch.Tensor:
+def kw_implicit_operator(x: torch.Tensor, y: torch.Tensor, a, b ,c, d=10) -> torch.Tensor:
     return x + y
 
 
@@ -220,6 +220,9 @@ def test_implicit_kw_args(tmp_path):
         load_module=False,
         reuse='override',
     )
+    # d=10 is default value and not passed in, so it should not appear in the gencode
+    # a/b/c are passed in as args, but they are not listed in the annotation of the operator,
+    # so they should be treated as kwargs in the gencode
     assert _gencode_contains(tmp_path, ImplicitKwModule, 0,
         r'tests.parallel_module.test_gencode_kwargs.kw_implicit_operator\(x_\d+, self.scale_\d+, a=3, b=4, c=5\)')
     # code looks like:

--- a/tests/runtime/test_device_group.py
+++ b/tests/runtime/test_device_group.py
@@ -1,0 +1,33 @@
+import warnings
+
+import torch.distributed as dist
+
+from nnscaler import init, uninit
+
+from ..launch_torchrun import launch_torchrun
+
+
+def _barrier_worker():
+    init()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for _ in range(3):
+            dist.barrier()
+
+    # make sure there is no barrier() device warning
+    # UserWarning: barrier(): using the device under current context. You can specify device_id in init_process_group to mute this warning.
+    # return func(*args, **kwargs)
+    barrier_warnings = [
+        w for w in caught
+        if issubclass(w.category, UserWarning)
+        and 'barrier()' in str(w.message)
+        and 'device_id' in str(w.message)
+    ]
+    assert len(barrier_warnings) == 0
+
+    uninit()
+
+
+def test_barrier_warning():
+    launch_torchrun(2, _barrier_worker)

--- a/tests/runtime/test_device_group.py
+++ b/tests/runtime/test_device_group.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pytest
+import torch
 import torch.distributed as dist
 
 from nnscaler import init, uninit
@@ -29,6 +31,6 @@ def _barrier_worker():
     finally:
         uninit()
 
-
+@pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason='lack of gpu devices')
 def test_barrier_warning():
     launch_torchrun(2, _barrier_worker)

--- a/tests/runtime/test_device_group.py
+++ b/tests/runtime/test_device_group.py
@@ -10,23 +10,24 @@ from ..launch_torchrun import launch_torchrun
 def _barrier_worker():
     init()
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        for _ in range(3):
-            dist.barrier()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            for _ in range(3):
+                dist.barrier()
 
-    # make sure there is no barrier() device warning
-    # UserWarning: barrier(): using the device under current context. You can specify device_id in init_process_group to mute this warning.
-    # return func(*args, **kwargs)
-    barrier_warnings = [
-        w for w in caught
-        if issubclass(w.category, UserWarning)
-        and 'barrier()' in str(w.message)
-        and 'device_id' in str(w.message)
-    ]
-    assert len(barrier_warnings) == 0
-
-    uninit()
+        # make sure there is no barrier() device warning
+        # UserWarning: barrier(): using the device under current context. You can specify device_id in init_process_group to mute this warning.
+        # return func(*args, **kwargs)
+        barrier_warnings = [
+            w for w in caught
+            if issubclass(w.category, UserWarning)
+            and 'barrier()' in str(w.message)
+            and 'device_id' in str(w.message)
+        ]
+        assert len(barrier_warnings) == 0
+    finally:
+        uninit()
 
 
 def test_barrier_warning():

--- a/tests/runtime/test_device_group.py
+++ b/tests/runtime/test_device_group.py
@@ -31,6 +31,7 @@ def _barrier_worker():
     finally:
         uninit()
 
+
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason='lack of gpu devices')
 def test_barrier_warning():
     launch_torchrun(2, _barrier_worker)


### PR DESCRIPTION
Ensure the device_id is specified in the init_process_group to prevent warnings during barrier synchronization in distributed training. 