### PR TITLE
[Refine] Policy fn: Add options to disable multiref  shared parameters in pipeline.

### DIFF
--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -782,8 +782,8 @@ def fn(
     pp_size = cfg.pas_config.get('pipeline_size', nstages)
     nmicros = cfg.pas_config.get('pipeline_nmicros', None)
     scheduler = cfg.pas_config.get('pipeline_scheduler', '1f1b')
-    pp_multiref_replicated_param = \
-        cfg.pas_config.get('pipeline_multiref_replicated_param', True)
+    pp_multiref_replicated_params = \
+        cfg.pas_config.get('pipeline_multiref_replicated_params', True)
     tp_size = ngpus // pp_size
 
     if pp_enabled:
@@ -836,7 +836,7 @@ def fn(
         # 4. (2) and (3): if the param is shared across stages and is replicated in at least one stage.
         #    Note: the case when some is replicated and some is partitioned is handled by (1).
 
-        if len(splits) > 1 or (pp_multiref_replicated_param and len(stage_info) > 1 and find_replicated):
+        if len(splits) > 1 or (pp_multiref_replicated_params and len(stage_info) > 1 and find_replicated):
             _logger.info(f'add multiref for shared param {ftensor}')
             graph.multiref(ftensor, comment='shared param')
 

--- a/nnscaler/policies.py
+++ b/nnscaler/policies.py
@@ -782,6 +782,8 @@ def fn(
     pp_size = cfg.pas_config.get('pipeline_size', nstages)
     nmicros = cfg.pas_config.get('pipeline_nmicros', None)
     scheduler = cfg.pas_config.get('pipeline_scheduler', '1f1b')
+    pp_multiref_replicated_param = \
+        cfg.pas_config.get('pipeline_multiref_replicated_param', True)
     tp_size = ngpus // pp_size
 
     if pp_enabled:
@@ -834,7 +836,7 @@ def fn(
         # 4. (2) and (3): if the param is shared across stages and is replicated in at least one stage.
         #    Note: the case when some is replicated and some is partitioned is handled by (1).
 
-        if len(splits) > 1 or (len(stage_info) > 1 and find_replicated):
+        if len(splits) > 1 or (pp_multiref_replicated_param and len(stage_info) > 1 and find_replicated):
             _logger.info(f'add multiref for shared param {ftensor}')
             graph.multiref(ftensor, comment='shared param')
 

--- a/tests/parallel_module/test_gencode_partition.py
+++ b/tests/parallel_module/test_gencode_partition.py
@@ -607,7 +607,8 @@ class PPSharedModel(torch.nn.Module):
 
 
 @replace_all_device_with('cpu')
-def test_pp_shared_model(tmp_path):
+@pytest.mark.parametrize('pipeline_multiref_replicated_params', [False, True])
+def test_pp_shared_model(tmp_path, pipeline_multiref_replicated_params):
     m = PPSharedModel(4)
     m.train()
     parallelize(
@@ -618,6 +619,7 @@ def test_pp_shared_model(tmp_path):
             pas_config={
                 'pipeline_nmicros': 2,
                 'pipeline_size': 2,
+                'pipeline_multiref_replicated_params': pipeline_multiref_replicated_params,
             }
         ),
         gen_savedir=tmp_path,
@@ -628,7 +630,7 @@ def test_pp_shared_model(tmp_path):
     # and only it should register it as a parameter
     # (the other stage gets it as a non-parameter shared input)
     for rank in range(4):
-        if rank % 2 == 0:
+        if rank % 2 == 0 or not pipeline_multiref_replicated_params:
             assert _gencode_contains(tmp_path, PPSharedModel, rank, r'self.register_parameter\(')
         else:
             assert not _gencode_contains(tmp_path, PPSharedModel, rank, r'self.register_parameter\(')


### PR DESCRIPTION
Adds a new configuration switch for fn policy to control whether pipeline-parallel stages insert multiref for shared parameters in pipeline