### PR TITLE
Add AGENTS.md and nsys-perf-debugging skill for coding agents

### DIFF
--- a/.agents/skills/nsys-perf-debugging.md
+++ b/.agents/skills/nsys-perf-debugging.md
@@ -1,0 +1,173 @@
+---
+name: nsys-perf-debugging
+description: Use NVIDIA Nsight Systems (nsys) to profile and debug nnscaler training performance. USE WHEN the user reports low TFLOPS / tokens-per-second, suspected pipeline bubble, or suspected communication-compute serialization in a parallelized nnscaler run, and you need to capture a trace, localize the bottleneck to an nnscaler subsystem, change the right layer, and re-measure without being misled by the compile cache.
+---
+
+# Skill: nsys-perf-debugging
+
+Use this skill for the nsys → diagnose → change → re-measure loop on nnscaler training. Before you start, read [AGENTS.md](../../AGENTS.md) §2 (pipeline), §3 (routing table), and §4 (footguns — especially cache invalidation).
+
+---
+
+## 0. Prerequisites
+
+- `nsys` (Nsight Systems) installed and on `PATH`. Verify: `nsys --version`.
+- An nnscaler training entry that reproduces the perf issue. Prefer the **smallest config that still shows the symptom** — short iteration loops dominate the quality of every step below.
+- Know which command + `ComputeConfig` produced the current numbers. Record these alongside every trace.
+
+---
+
+## 1. Capture a baseline trace
+
+Wrap your training script with `nsys profile`. A reasonable default for distributed PyTorch with NCCL:
+
+```bash
+nsys profile \
+    -o baseline \
+    --trace=cuda,nvtx,osrt,cudnn,cublas \
+    --cuda-memory-usage=true \
+    --capture-range=cudaProfilerApi \
+    --capture-range-end=stop \
+    -f true \
+    python <train_entry> <args>
+```
+
+Notes:
+- Use `--capture-range=cudaProfilerApi` and wrap a few warm iterations + a few measured iterations with `torch.cuda.profiler.start()` / `stop()` (or `cudaProfilerStart/Stop`). Profiling the whole run produces multi-GB traces that are slow to open.
+- For multi-rank runs, profile only **one or two ranks** of interest — typically rank 0 plus a suspected slow stage. Set `NSYS_OUTPUT` per rank or use `--output=trace_rank%q{RANK}`.
+- Add NVTX ranges in the training loop (`torch.cuda.nvtx.range_push/pop`) around `forward`, `backward`, `optimizer.step`, and around each pipeline micro-batch if your entry doesn't already. This makes the timeline readable.
+
+Record alongside the trace: git SHA, branch, command, `ComputeConfig`, world size, TP/DP/PP shape, and the four headline numbers: **TFLOPS, tokens/s, peak memory, iteration time**.
+
+---
+
+## 2. Read the generated code first
+
+Before opening the trace, open `.nnscaler/_parallel_modules/__main__/{ModelName}/_/gencode{rank}.py` for the rank you profiled. This is the fastest way to learn what the compiler actually emitted: which `torch.cuda.stream(...)` each collective lands on, where `synchronize()` calls sit, where activations are released. The trace will make a lot more sense afterward, and many "mystery" serializations are obvious from the source.
+
+---
+
+## 3. Localize from the CLI
+
+Coding agents run headless — use `nsys stats` and `nsys analyze` to extract structured summaries from the `.nsys-rep` file, not the GUI. Useful reports:
+
+```bash
+# Top CUDA kernels by total GPU time (compute hotspots)
+nsys stats --report cuda_gpu_kern_sum --format csv,column baseline.nsys-rep | head -40
+
+# NCCL / communication kernel breakdown
+nsys stats --report cuda_gpu_kern_sum --format csv baseline.nsys-rep \
+    | awk -F, 'NR==1 || /nccl|ncclKernel/'
+
+# Per-stream activity — reveals whether comm and compute share a stream
+nsys stats --report cuda_gpu_trace --format csv baseline.nsys-rep \
+    | awk -F, 'NR==1 || $0 ~ /nccl/' | head -40
+
+# CUDA API calls — large cudaStreamSynchronize / cudaEventSynchronize totals
+# indicate forced serialization
+nsys stats --report cuda_api_sum --format csv,column baseline.nsys-rep | head -30
+
+# NVTX range summary — per-phase (fwd/bwd/opt/microbatch) wall time
+nsys stats --report nvtx_pushpop_sum --format csv,column baseline.nsys-rep | head -40
+
+# Built-in expert-system rules (idle GPU, low occupancy, sync misuse, etc.)
+nsys analyze baseline.nsys-rep
+```
+
+Work top-down on the output:
+
+1. **Which rank / pipeline stage** is on the critical path? Compare per-rank traces. The slow rank is the one with the longest wall time between iteration-start and iteration-end NVTX ranges; idle ranks are waiting on it.
+2. **Which phase** dominates? Use the `nvtx_pushpop_sum` report — `forward` / `backward` / `optimizer` / per-microbatch totals.
+3. **Which kernel category** dominates? Aggregate `cuda_gpu_kern_sum` by name prefix:
+   - `ncclKernel_*` / `nccl*` → communication.
+   - `ampere_*gemm*`, `cutlass*`, `flash_*`, `attn*` → compute.
+   - `Memcpy*` / `Memset*` → data movement.
+   - Large gaps in `cuda_gpu_trace` with high `cudaStreamSynchronize` totals in `cuda_api_sum` → CPU/Python overhead or forced sync.
+4. **Comm/compute overlap check**: in `cuda_gpu_trace`, identify the stream IDs of NCCL kernels vs. compute kernels. If they share a stream ID, overlap is structurally impossible. If they are on different streams but their `[Start, Start+Duration]` intervals don't overlap, look for a `cudaStreamWaitEvent` / `cudaEventSynchronize` between them in `cuda_api_sum`.
+
+Then map symptom → suspect subsystem using AGENTS.md §3 and the table below.
+
+---
+
+## 4. Symptom → suspect subsystem (nnscaler-specific)
+
+| What you see in nsys | First place to look | Notes |
+|---|---|---|
+| Long idle gaps in the middle of an iteration on most ranks (pipeline bubble) | `pipeline_nmicros`, `pipeline_scheduler` in `ComputeConfig.pas_config`; [nnscaler/graph/schedule/predefined.py](../../nnscaler/graph/schedule/predefined.py) | Try `sched_1f1b_interleaved`; tune `num_stages` |
+| NCCL kernel (`ncclAllReduce` / `AllGather` / `ReduceScatter`) on the same stream as compute, or on a separate stream but the compute stream is event-waiting for its full duration | `use_multi_streams` flag, `_get_node_stream()` in [nnscaler/codegen/schedule/schedule.py](../../nnscaler/codegen/schedule/schedule.py); `StreamConfig` in [nnscaler/graph/schedule/schedplan.py](../../nnscaler/graph/schedule/schedplan.py); stream contexts in [nnscaler/runtime/device.py](../../nnscaler/runtime/device.py) | Confirm in `gencode{rank}.py` that the collective is wrapped in `torch.cuda.stream(...)` |
+| Many tiny NCCL kernels back-to-back | Adapter fusion in [nnscaler/execplan/planpass/fusion.py](../../nnscaler/execplan/planpass/fusion.py) (`DiffFusion.nnfuse`); gradient bucketing in [nnscaler/runtime/adapter/reducer.py](../../nnscaler/runtime/adapter/reducer.py) | |
+| `ncclSend` / `ncclRecv` at stage boundary blocks the next compute on the same stage | Schedule order in [nnscaler/graph/schedule/interleaved_1f1b.py](../../nnscaler/graph/schedule/interleaved_1f1b.py) (SEND_F / RECV_F / SEND_B / RECV_B placement); `move()` in [nnscaler/runtime/adapter/collectives.py](../../nnscaler/runtime/adapter/collectives.py) | If schedule issues comm too late, no amount of stream juggling will overlap it |
+| Spurious `cudaStreamSynchronize` / event-wait near a collective | Codegen sync emission in [nnscaler/codegen/schedule/schedule.py](../../nnscaler/codegen/schedule/schedule.py); `synchronize_streams` in [nnscaler/runtime/module.py](../../nnscaler/runtime/module.py) | |
+| OOM with otherwise-good throughput | Recomputation (`recompute_modules`), micro-batch count, schedule choice; tensor lifecycle in [nnscaler/codegen/lifecycle.py](../../nnscaler/codegen/lifecycle.py) | |
+| Autodist picked an obviously bad plan | Profile DB likely stale, or cost-model gap; [nnscaler/autodist/cost_database.py](../../nnscaler/autodist/cost_database.py), [nnscaler/autodist/op_partition.py](../../nnscaler/autodist/op_partition.py) | Delete `~/.cache/nnscaler/autodist/...` before retrying |
+| Compute kernel itself is slow (one big GEMM / attn) | Custom op / kernel choice in [nnscaler/customized_ops/](../../nnscaler/customized_ops/); op dim annotations | Not an nnscaler-orchestration problem — fix the op |
+
+If the symptom is comm/compute serialization, also verify in this order: (a) is `use_multi_streams` even on? (b) is the comm wrapped in a non-default stream in `gencode{rank}.py`? (c) does the schedule issue the comm early enough to overlap?
+
+---
+
+## 5. Hypothesize and change
+
+Write one sentence per change: *"I expect changing X in [file] to reduce Y by Z%, because …"*. If you can't fill in `because`, go back to §3 — you are guessing.
+
+You may touch multiple subsystems from AGENTS.md §3 in a single iteration if the hypothesis genuinely requires it (e.g. a new prim in `ir/adapter/` plus its emission in `codegen/`). Just be aware that the more layers you change at once, the harder attribution becomes — if the re-measure is ambiguous, split the change.
+
+Edit the **generator / schedule / policy**, never the emitted `gencode{rank}.py` (see AGENTS.md §4).
+
+---
+
+## 6. Invalidate the cache (the #1 cause of "my change did nothing")
+
+When you change anything in `nnscaler/graph/`, `nnscaler/execplan/`, `nnscaler/codegen/`, `nnscaler/autodist/`, `nnscaler/policies.py`, or `nnscaler/ir/adapter/`, you must invalidate:
+
+| Cache | Path | How to invalidate |
+|---|---|---|
+| Generated per-rank module | `.nnscaler/_parallel_modules/__main__/{ModelName}/_/gencode{rank}.py` (+ `fullmodel.pt`) | `compile(..., override=True)` / `ComputeConfig(..., override=True)`; or `rm -rf .nnscaler/` |
+| Autodist profile DB (op / comm costs) | `~/.cache/nnscaler/autodist/{version}/{GPU_name}/` | `rm -rf` the directory; required when op cost characteristics change (new fusion, new prim, kernel-level change) |
+
+**Verification before re-measuring**: diff the new `gencode{rank}.py` against the previous one.
+
+```bash
+# quick sanity diff after a code change
+diff -u .nnscaler.prev/.../gencode0.py .nnscaler/.../gencode0.py | head -80
+```
+
+If the file is byte-identical, the cache was not invalidated and any perf number you collect is meaningless.
+
+---
+
+## 7. Re-measure with the same nsys recipe
+
+- Same command, same config, same hardware state as §1. Output to a new file (e.g. `-o after_change`).
+- Report the same four numbers: TFLOPS, tokens/s, peak memory, iteration time.
+- Re-run the same `nsys stats` reports as §3 on both traces and **diff them**. State the timeline change in one sentence (e.g. *"NCCL AllGather on stage 2 moved from stream 7 to stream 13 and its interval now overlaps bwd matmul; stage-0 bubble unchanged"*). A throughput win with no visible change in the per-stream / per-kernel breakdown is usually noise or a measurement bug.
+
+---
+
+## 8. Correctness gate
+
+Before claiming a win, validate loss/grad parity on a tiny config (single-GPU baseline vs. the changed parallel config), as in AGENTS.md §4. Overlap fixes in particular frequently introduce races on activations or gradients.
+
+---
+
+## 9. Reporting format (use in PR descriptions)
+
+```
+Config:      <model, layers, seq, batch, world size, TP/DP/PP>
+Baseline:    TFLOPS=__  tok/s=__  peak_mem=__  iter=__ms
+After:       TFLOPS=__  tok/s=__  peak_mem=__  iter=__ms
+Change:      <one sentence: which subsystem, which file, what>
+Trace diff:  <relevant lines from `nsys stats` before/after: which kernel/stream moved>
+Cache:       override=True / .nnscaler removed / profile DB removed (yes/no each)
+Correctness: loss-parity on <tiny config> — pass/fail
+```
+
+---
+
+## Anti-patterns to refuse
+
+- Hand-patching `gencode{rank}.py` to "fix" a comm placement — erased on next compile.
+- Adding `torch.cuda.synchronize()` to make a race go away — defeats overlap; find the missing dependency instead.
+- Disabling `use_multi_streams` because it's racy — fix the race, don't surrender overlap.
+- Lowering micro-batch count until the bubble hides the comm — masks the bug.
+- Reporting a TFLOPS improvement without a corresponding timeline change in the trace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AGENTS.md — nnscaler
+
+Guidance for coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo. Read this file before proposing changes. Task-specific procedures live as skills under [.agents/skills/](.agents/skills/) — load the matching one when relevant.
+
+---
+
+## 1. What nnscaler is
+
+nnscaler is a compiler + runtime for distributed PyTorch training. It **traces** a user model, lowers it to an **IR**, runs **graph transforms + auto-distribution** to pick a TP/DP/PP parallelization strategy, builds an **execution plan / schedule**, **generates** per-rank Python modules, and runs them through its **runtime** (CUDA streams + NCCL collectives).
+
+The single most important consequence: behavior you observe at runtime — performance, memory, numerical layout — is the product of decisions made at *every* stage of that pipeline. Most non-trivial changes touch more than one layer.
+
+---
+
+## 2. Compilation pipeline (mental model)
+
+```
+user model  ─►  trace  ─►  IR  ─►  graph partition / RVD  ─►  autodist policy
+                                                                    │
+                                                                    ▼
+        runtime (streams, collectives)  ◄──  gencode{rank}.py  ◄──  codegen  ◄──  execplan / schedule
+```
+
+| Stage | Owns | Lives in |
+|---|---|---|
+| Trace / orchestration | entry points, compile cache, `ComputeConfig`, `ParallelModule` | [nnscaler/compiler.py](nnscaler/compiler.py), [nnscaler/parallel.py](nnscaler/parallel.py), [nnscaler/program.py](nnscaler/program.py) |
+| IR | tensor / op representation, layouts, adapter & comm primitives | [nnscaler/ir/](nnscaler/ir/), esp. [nnscaler/ir/adapter/prim.py](nnscaler/ir/adapter/prim.py) |
+| Graph | partition, fwd/bwd segmentation, pipeline schedules, RVD adapter selection | [nnscaler/graph/](nnscaler/graph/), schedules under [nnscaler/graph/schedule/](nnscaler/graph/schedule/) |
+| Autodist | TP/DP/PP search, cost model, partition options, policies | [nnscaler/autodist/](nnscaler/autodist/), [nnscaler/policies.py](nnscaler/policies.py) |
+| ExecPlan | per-device op sequence, adapter fusion, multi-stream flag | [nnscaler/execplan/](nnscaler/execplan/) |
+| Codegen | emitted `_train_step`, stream contexts, tensor lifecycle | [nnscaler/codegen/](nnscaler/codegen/) |
+| Runtime | streams, collectives, async work, gradient bucketing | [nnscaler/runtime/](nnscaler/runtime/) |
+| Profiler | op/comm cost DB consumed by autodist solver | [nnscaler/profiler/](nnscaler/profiler/) |
+| Custom ops / examples | user-facing ops and reference training entries | [nnscaler/customized_ops/](nnscaler/customized_ops/), [examples/](examples/) |
+
+Every one of these layers is **part of nnscaler and may be modified**. A common agent mistake is treating generated code, schedules, or the IR as immutable; they are outputs of code in this repo, and the right fix usually lives in the layer that produced them, not downstream of it.
+
+---
+
+## 3. Where common kinds of work belong
+
+This is a routing table, not an exhaustive list. Use it to pick the right layer before you start editing.
+
+| Kind of task | Primary layer | Secondary / often touched |
+|---|---|---|
+| Add support for a new model architecture | [examples/](examples/) (training entry), possibly [nnscaler/customized_ops/](nnscaler/customized_ops/) for novel ops | Custom op registration ([docs/source/register_custom_op.md](docs/source/register_custom_op.md)); partition constraints if autodist picks a bad plan |
+| Add a custom op (e.g. fused attention) | [nnscaler/customized_ops/](nnscaler/customized_ops/) | Dim annotations ([docs/source/dimops.md](docs/source/dimops.md)); profiler entry if it changes cost meaningfully |
+| New collective / comm primitive | [nnscaler/ir/adapter/prim.py](nnscaler/ir/adapter/prim.py) + [nnscaler/runtime/adapter/collectives.py](nnscaler/runtime/adapter/collectives.py) | Fusion in [nnscaler/execplan/planpass/fusion.py](nnscaler/execplan/planpass/fusion.py); codegen if it needs special emission |
+| New pipeline schedule | [nnscaler/graph/schedule/predefined.py](nnscaler/graph/schedule/predefined.py) (+ [schedplan.py](nnscaler/graph/schedule/schedplan.py)) | Schedule registry in [nnscaler/parallel.py](nnscaler/parallel.py); emission in [nnscaler/codegen/schedule/schedule.py](nnscaler/codegen/schedule/schedule.py) |
+| Change parallelization policy / solver heuristic | [nnscaler/policies.py](nnscaler/policies.py), [nnscaler/autodist/](nnscaler/autodist/) | Profile DB invalidation if op costs change |
+| Constrain the solver for a specific model | User-side `ComputeConfig.pas_config` + [docs/source/partition_constraints_guide.md](docs/source/partition_constraints_guide.md) | Usually no nnscaler-side change |
+| Improve comm/compute overlap | Stream assignment in [nnscaler/codegen/schedule/schedule.py](nnscaler/codegen/schedule/schedule.py) (`_get_node_stream`); `StreamConfig` in [nnscaler/graph/schedule/schedplan.py](nnscaler/graph/schedule/schedplan.py); runtime in [nnscaler/runtime/](nnscaler/runtime/) | |
+| Reduce memory / OOM | Recomputation flags; pipeline schedule choice; micro-batch count; tensor lifecycle in [nnscaler/codegen/lifecycle.py](nnscaler/codegen/lifecycle.py) | |
+| Fix codegen bug (wrong emitted code) | [nnscaler/codegen/](nnscaler/codegen/) — *not* the generated file | Add a regression test under [tests/codegen/](tests/codegen/) |
+| Runtime bug (hang, wrong gradient, NCCL error) | [nnscaler/runtime/](nnscaler/runtime/) | Often the upstream cause is in codegen or schedule |
+
+If a task plausibly fits two rows, edit the **earlier** layer in the pipeline (§2) — fixes downstream of a buggy generator are erased on the next compile.
+
+---
+
+## 4. Footguns (read before editing)
+
+- **Read the generated files, but do not hand-edit them.** Generated per-rank code lives at `.nnscaler/_parallel_modules/__main__/{ModelName}/_/gencode{rank}.py`. Reading `gencode{rank}.py` is often the fastest way to understand what the compiler actually produced — which stream a collective lands on, where syncs sit, what the lifecycle looks like — and is highly recommended when debugging or optimizing. But any patch there is erased on the next compile; fix the generator (codegen / schedule / execplan) instead.
+- **Stale compile cache silently invalidates results.** `compile(..., override=False)` reuses prior gencode and the autodist solution with no warning. When you change anything in `nnscaler/graph/`, `nnscaler/execplan/`, `nnscaler/codegen/`, `nnscaler/autodist/`, `nnscaler/policies.py`, or `nnscaler/ir/adapter/`, you must invalidate:
+  - set `override=True` in `compile()` / `ComputeConfig`, **and/or**
+  - delete `.nnscaler/` (gencode), **and/or**
+  - delete `~/.cache/nnscaler/autodist/{version}/{GPU}/` (profile DB — required when op cost characteristics change).
+- **Verify a change took effect by diffing the new `gencode{rank}.py` against the previous one.** If they are byte-identical, the cache was not invalidated.
+- **Don't change op signatures without re-registering** the custom op — see [docs/source/register_custom_op.md](docs/source/register_custom_op.md).
+- **Don't disable correctness checks to make tests or perf numbers go green.** Validate loss/grad parity on a small config (single-GPU vs. parallel) before claiming a feature or perf win.
+
+---
+
+## 5. Testing and measurement entry points
+
+- **Unit / integration tests:** [tests/](tests/) — per-subsystem layout (`codegen/`, `graph/`, `runtime/`, `autodist/`, `parallel_module/`, …). Run with `pytest tests/<area>`.
+- **RVD primitives correctness:** [utility/test_rvd_prim.py](utility/test_rvd_prim.py) with `--prims all`.
+- **Comm latency micro-bench:** `python -m nnscaler.profiler.benchmark_comm`.
+- **Benchmark scripts:** [benchmark/](benchmark/) (`benchmark_ring_attn.py`, `benchmark_zigzag_attn.py`, …).
+- **Reference training entry:** [examples/llama/train.py](examples/llama/train.py).
+
+When measuring performance, use the **smallest config that reproduces the phenomenon** — short iteration loops dominate the quality of the optimization process.
+
+---
+
+## 6. Existing documentation worth knowing about
+
+- [docs/source/parallel_module.md](docs/source/parallel_module.md) — `ParallelModule` / `ComputeConfig`
+- [docs/source/register_custom_op.md](docs/source/register_custom_op.md) — custom op registration
+- [docs/source/dimops.md](docs/source/dimops.md) — dim-annotated ops
+- [docs/source/partition_constraints_guide.md](docs/source/partition_constraints_guide.md) — constraining the autodist solver
+- [docs/source/trainer.md](docs/source/trainer.md), [docs/source/pytorch_lightning.md](docs/source/pytorch_lightning.md) — trainer integrations
+- [docs/source/troubleshooting.rst](docs/source/troubleshooting.rst)
+- [docs/source/control_flow.md](docs/source/control_flow.md), [docs/source/einops.md](docs/source/einops.md), [docs/source/verify_op.md](docs/source/verify_op.md)
+
+---
+
+## 7. Maintainer note
+
+This file describes **stable architecture and routing**, not APIs. When a layer in §2 changes shape (not just internals), update the corresponding row and any affected skill. Stale guidance is worse than none — agents will confidently edit the wrong layer.


### PR DESCRIPTION
## Summary

Adds agent-facing project documentation so coding agents (Claude Code, Copilot, Cursor, etc.) operate on an accurate model of nnscaler instead of inferring one from the file tree. Motivated by recurring failure modes observed during pipeline-parallel performance work (e.g. YOCO on `yileiyang/yoco_pp`), where agents assumed generated code and pipeline schedules were out-of-scope and consequently never proposed the right fix.

## What's added

- **`AGENTS.md`** at repo root — stable architecture + routing for any coding agent:
  - Compilation pipeline mental model (trace → IR → graph → autodist → execplan → codegen → runtime), with the file/dir that owns each stage.
  - "Where common kinds of work belong" routing table covering model support, custom ops, new collectives, new pipeline schedules, solver heuristics, comm/compute overlap, memory, codegen bugs, runtime bugs.
  - Footguns: don't hand-edit generated files (but **do read them** — it's the fastest way to see what the compiler actually emitted); silent compile-cache reuse with `override=False`; profile-DB invalidation when op costs change; op re-registration; correctness-before-perf.
  - Pointers to existing `docs/source/` material.
- **`.agents/skills/nsys-perf-debugging.md`** — single starter skill, loaded on demand:
  - `nsys profile` capture recipe (capture range, per-rank output, NVTX hints).
  - CLI-only diagnosis using `nsys stats` reports (`cuda_gpu_kern_sum`, `cuda_gpu_trace`, `cuda_api_sum`, `nvtx_pushpop_sum`) and `nsys analyze` — no GUI assumed.
  - Symptom → suspect-subsystem table specific to nnscaler (pipeline bubble, NCCL/compute serialization, tiny collectives, P2P at stage boundary, spurious syncs, OOM, bad autodist plan, slow compute kernel).
  - Cache-invalidation discipline + a verification diff step.
  - Re-measure / correctness / PR reporting template / anti-patterns.

## Why

Agents pick up scope priors very reliably from `AGENTS.md`-style files. The two highest-ROI things to encode are (1) **what is in-scope** for optimization (IR, schedule, codegen, runtime are all editable; generated `gencode{rank}.py` is not) and (2) **how to invalidate the compile cache**, which is the most common reason a change appears to have no effect. Both are in §3–§4 of `AGENTS.md` and reinforced in the skill.

## Scope intentionally kept narrow

- `AGENTS.md` describes stable architecture + routing only. APIs drift; layer ownership doesn't. Maintainer note at the bottom flags that any change to a layer's *shape* (not internals) should update the routing table.
- Only one skill to start. Additional skills (e.g. `add-custom-op`, `add-pipeline-schedule`, `add-model-support`) should be added when a workflow actually recurs, rather than written speculatively.
- No changes to source code, tests, or build.

## How to try it

Point an agent (Claude Code, Copilot Chat) at a perf task on a parallelized nnscaler run; the skill description (`USE WHEN low TFLOPS / pipeline bubble / comm-compute serialization…`) should cause it to load `nsys-perf-debugging.md` automatically.

## Maintenance

When a layer in `AGENTS.md` §2 changes *shape*, update the corresponding row and the skill. Stale guidance is worse than none — agents will confidently edit the wrong layer.