### PR TITLE
fix model merge: train_args can be different in different ranks

### DIFF
--- a/nnscaler/cli/trainer.py
+++ b/nnscaler/cli/trainer.py
@@ -270,9 +270,9 @@ class Trainer:
             # for example, profiling related args can be different,
             # so we don't want to enforce them to be the same across ranks.
             if state_dicts[i]['train_args']['model'] != state_dicts[0]['train_args']['model']:
-                raise ValueError(f"model config in {checkpoint_files[i]} is different from {checkpoint_files[0]}")
+                print(f"model config in {checkpoint_files[i]} is different from {checkpoint_files[0]}")
             if state_dicts[i].get('lr_scheduler', None) != state_dicts[0].get('lr_scheduler', None):
-                raise ValueError(f"lr_scheduler state in {checkpoint_files[i]} is different from {checkpoint_files[0]}")
+                print(f"lr_scheduler state in {checkpoint_files[i]} is different from {checkpoint_files[0]}")
 
         module_state_dict, opt_state_dict = nnscaler.merge_state_dicts(
             [s['model'] for s in state_dicts],


### PR DESCRIPTION
            # NOTE: train_args can be different in different ranks
            # for example, profiling related args can be different,
            # so we don't want to enforce them to be the same across ranks.