### PR TITLE
[Refine] Refine communication cost estimation and add tests

### DIFF
--- a/nnscaler/graph/gener/rvd/inter.py
+++ b/nnscaler/graph/gener/rvd/inter.py
@@ -497,7 +497,7 @@ class InterPathFinder:
         # so we only consider the first primitive for cost estimation?
         icost = cost_fn(prims[0])
         # gather all
-        # consider differnt linkbandwidth intra NVLink 300GB/s vs. inter-node 100Gbps
+        # consider different linkbandwidth intra NVLink 300GB/s vs. inter-node 100Gbps
         # disable comm_factor for now,
         # since we don't know whether InterTransition will happen in intra-node or inter-node,
         # and we don't have the information of device placement here

--- a/nnscaler/graph/gener/rvd/inter.py
+++ b/nnscaler/graph/gener/rvd/inter.py
@@ -492,10 +492,16 @@ class InterPathFinder:
             ftensor, r=prvds[-1][0], v=prvds[-1][1],
             dims=prvds[-1][2:], devices=list(range(pndevs)))
         _, prims = InterTransition.transition(playout, crvds[0], list(range(pndevs, pndevs + cndevs)))
+        # TODO: why only consider the first primitive? should we consider all primitives?
+        # because all primitives are executed in parallel (they are in different devices),
+        # so we only consider the first primitive for cost estimation?
         icost = cost_fn(prims[0])
         # gather all
         # consider differnt linkbandwidth intra NVLink 300GB/s vs. inter-node 100Gbps
-        comm_factor = 24
+        # disable comm_factor for now,
+        # since we don't know whether InterTransition will happen in intra-node or inter-node,
+        # and we don't have the information of device placement here
+        comm_factor = 1
         return pcost + ccost + icost * comm_factor
 
     @staticmethod

--- a/tests/graph/gener/test_inter_rvd.py
+++ b/tests/graph/gener/test_inter_rvd.py
@@ -99,11 +99,9 @@ def test_one_f_case2():
     assert rvds == (('p', 2, 1, 1, 1), ('c', 2, 1, 1, 1))
 
     assert len(fprims) == 2
-    # producer part, v->d, so reduce_scatter
     assert fprims[0].signature == 'nnscaler.runtime.adapter.move'
-    assert fprims[0].device == [0, 2]
     assert fprims[1].signature == 'nnscaler.runtime.adapter.move'
-    assert fprims[1].device == [1, 3]
+    assert set([tuple(fprims[0].device), tuple(fprims[1].device)]) == set([(0, 2), (1, 3)])
 
 
 def test_all_f_cases_fix_placement():

--- a/tests/graph/gener/test_inter_rvd.py
+++ b/tests/graph/gener/test_inter_rvd.py
@@ -98,7 +98,6 @@ def test_one_f_case2():
     fprims = InterPathFinder.path(fp_rvd, fc_rvd)
     assert rvds == (('p', 2, 1, 1, 1), ('c', 2, 1, 1, 1))
 
-    fprims = InterPathFinder.path(fp_rvd, fc_rvd)
     assert len(fprims) == 2
     # producer part, v->d, so reduce_scatter
     assert fprims[0].signature == 'nnscaler.runtime.adapter.move'

--- a/tests/graph/gener/test_inter_rvd.py
+++ b/tests/graph/gener/test_inter_rvd.py
@@ -75,6 +75,38 @@ def test_one_f_case():
     assert fprims[13].device == [11, 15]
 
 
+def test_one_f_case2():
+    fshape = [16, 16]
+
+    src_r, src_v, src_d = 2,1,(1,1)
+    dst_r, dst_v, dst_d = 2,1,(1,1)
+    src_rvd = (src_r, src_v) + src_d
+    dst_rvd = (dst_r, dst_v) + dst_d
+
+    pndevs = np.prod(src_rvd)
+    cndevs = np.prod(dst_rvd)
+
+    ftensor = IRFullTensor(shape=fshape, name='tensor', requires_grad=False)
+
+    pdevs = list(range(pndevs))
+    fp_rvd = RVDLayout.grid(ftensor, r=src_r, v=src_v, dims=src_d, devices=pdevs)
+
+    cdevs = list(range(pndevs, pndevs + cndevs))
+    fc_rvd = RVDLayout.grid(ftensor, r=dst_r, v=dst_v, dims=dst_d, devices=cdevs)
+
+    rvds = InterPathFinder.get_optimal_path(ftensor, src_rvd, dst_rvd)
+    fprims = InterPathFinder.path(fp_rvd, fc_rvd)
+    assert rvds == (('p', 2, 1, 1, 1), ('c', 2, 1, 1, 1))
+
+    fprims = InterPathFinder.path(fp_rvd, fc_rvd)
+    assert len(fprims) == 2
+    # producer part, v->d, so reduce_scatter
+    assert fprims[0].signature == 'nnscaler.runtime.adapter.move'
+    assert fprims[0].device == [0, 2]
+    assert fprims[1].signature == 'nnscaler.runtime.adapter.move'
+    assert fprims[1].device == [1, 3]
+
+
 def test_all_f_cases_fix_placement():
     fshape = [128, 256, 512]
     ftensor = IRFullTensor(shape=fshape, name='tensor', requires_grad=False)


### PR DESCRIPTION
Disable the cross-node penalty in cost estimation for communications between stages in the pipeline. Add a new test case to validate the functionality of the pathfinding logic. Fix a typo in the code.